### PR TITLE
refactor(go)!: rename telemetry YAML path

### DIFF
--- a/go/docs/schema/config.md
+++ b/go/docs/schema/config.md
@@ -16,7 +16,7 @@ settings:
     retry_on_status: [429, 500, 502, 503, 504]
     max_body_bytes: 33554432
 
-  observability:
+  telemetry:
     logs:
       exporter: "stdout"
     metrics:
@@ -173,7 +173,7 @@ uses `routes[].upstreams[].model`.
     `concurrency` maps internally to `consumer_quotas.quota_type = "concurrency"`.
   - `limits`: `max_input_tokens`, `max_output_tokens`,
     `max_request_body_bytes` — per-request caps; omitted/zero means no limit.
-- `settings.observability`: three independent signal blocks — `logs`,
+- `settings.telemetry`: three independent signal blocks — `logs`,
   `metrics`, `traces`. Each signal picks its own exporter and owns a flat set
   of engine-specific fields; there is no shared/global exporter, endpoint, or
   export interval. The authoritative field schema (per exporter kind, per
@@ -204,7 +204,7 @@ uses `routes[].upstreams[].model`.
     rejected — `stdout` takes no fields).
   - `retention` and `data_dir` are **not** part of this gateway YAML layer —
     they are admin-side control-plane configuration and never appear under
-    `settings.observability` here.
+    `settings.telemetry` here.
 
 ## Admin-only settings
 

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -26,21 +26,21 @@ type ProxySpec struct {
 	MaxBodyBytes   int64  `yaml:"max_body_bytes,omitempty"`
 }
 
-// ObservabilityLogsSpec is the YAML shape of settings.observability.logs.
+// TelemetryLogsSpec is the YAML shape of settings.telemetry.logs.
 // Exporter selects the engine (stdout/otlp); the remaining fields are the
 // engine-specific fields flattened directly into the spec (no nested
 // per-engine block) — see exporterFieldSetters for the exporter→field
 // mapping enforced against internal/telemetry/schema's registry.
-type ObservabilityLogsSpec struct {
+type TelemetryLogsSpec struct {
 	Exporter string `yaml:"exporter,omitempty"`
 	Endpoint string `yaml:"endpoint,omitempty"`
 	Protocol string `yaml:"protocol,omitempty"`
 	Interval string `yaml:"interval,omitempty"`
 }
 
-// ObservabilityMetricsSpec is the YAML shape of settings.observability.metrics.
+// TelemetryMetricsSpec is the YAML shape of settings.telemetry.metrics.
 // Exporter selects the engine (stdout/otlp/prometheus).
-type ObservabilityMetricsSpec struct {
+type TelemetryMetricsSpec struct {
 	Exporter string `yaml:"exporter,omitempty"`
 	Endpoint string `yaml:"endpoint,omitempty"`
 	Protocol string `yaml:"protocol,omitempty"`
@@ -49,83 +49,104 @@ type ObservabilityMetricsSpec struct {
 	Path     string `yaml:"path,omitempty"`
 }
 
-// ObservabilityTracesSpec is the YAML shape of settings.observability.traces.
+// TelemetryTracesSpec is the YAML shape of settings.telemetry.traces.
 // Exporter selects the engine (stdout/otlp).
-type ObservabilityTracesSpec struct {
+type TelemetryTracesSpec struct {
 	Exporter string `yaml:"exporter,omitempty"`
 	Endpoint string `yaml:"endpoint,omitempty"`
 	Protocol string `yaml:"protocol,omitempty"`
 	Interval string `yaml:"interval,omitempty"`
 }
 
-// ObservabilitySpec holds the three per-signal blocks. Each field is a
+// TelemetrySpec holds the three per-signal blocks. Each field is a
 // pointer so unmarshal can distinguish "block absent from YAML" (nil — the
 // signal is silently disabled) from "block present but empty/incomplete"
 // (non-nil with a zero Exporter — a validation error, since a present block
 // must declare which engine to use).
-type ObservabilitySpec struct {
-	Logs    *ObservabilityLogsSpec    `yaml:"logs,omitempty"`
-	Metrics *ObservabilityMetricsSpec `yaml:"metrics,omitempty"`
-	Traces  *ObservabilityTracesSpec  `yaml:"traces,omitempty"`
+type TelemetrySpec struct {
+	Logs    *TelemetryLogsSpec    `yaml:"logs,omitempty"`
+	Metrics *TelemetryMetricsSpec `yaml:"metrics,omitempty"`
+	Traces  *TelemetryTracesSpec  `yaml:"traces,omitempty"`
 }
 
 // UnmarshalYAML implements custom decoding so that "key present in the YAML
 // document" can be distinguished from "key absent" independently of the
 // value's YAML kind. Standard struct-tag decoding maps both a fully absent
 // `logs:` key and a present-but-null one (bare `logs:`, or `logs:\n  #
-// comment`) to the same nil *ObservabilityLogsSpec, which loses the
+// comment`) to the same nil *TelemetryLogsSpec, which loses the
 // distinction flattenSettings relies on ("present but empty" must error,
 // "absent" must silently disable). Here each of logs/metrics/traces is only
 // left nil when its key does not appear in node.Content at all; if the key
 // is present, the pointer is always allocated (decoding its value when the
 // value is not the YAML null scalar, leaving a zero-value struct — i.e. no
 // exporter set — otherwise), matching `logs: {}` behavior.
-func (o *ObservabilitySpec) UnmarshalYAML(node *yaml.Node) error {
+func (t *TelemetrySpec) UnmarshalYAML(node *yaml.Node) error {
 	if node.Kind == 0 || node.Tag == "!!null" {
-		// observability key absent, or present but null (bare `observability:`)
+		// telemetry key absent, or present but null (bare `telemetry:`)
 		// — treat as no signal blocks present, same as omitting the key.
-		*o = ObservabilitySpec{}
+		*t = TelemetrySpec{}
 		return nil
 	}
 	if node.Kind != yaml.MappingNode {
-		return fmt.Errorf("observability: expected a mapping, got %v", node.Kind)
+		return fmt.Errorf("telemetry: expected a mapping, got %v", node.Kind)
 	}
-	*o = ObservabilitySpec{}
+	*t = TelemetrySpec{}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		keyNode, valNode := node.Content[i], node.Content[i+1]
 		switch keyNode.Value {
 		case "logs":
-			spec := &ObservabilityLogsSpec{}
+			spec := &TelemetryLogsSpec{}
 			if valNode.Tag != "!!null" {
 				if err := valNode.Decode(spec); err != nil {
-					return fmt.Errorf("observability.logs: %w", err)
+					return fmt.Errorf("telemetry.logs: %w", err)
 				}
 			}
-			o.Logs = spec
+			t.Logs = spec
 		case "metrics":
-			spec := &ObservabilityMetricsSpec{}
+			spec := &TelemetryMetricsSpec{}
 			if valNode.Tag != "!!null" {
 				if err := valNode.Decode(spec); err != nil {
-					return fmt.Errorf("observability.metrics: %w", err)
+					return fmt.Errorf("telemetry.metrics: %w", err)
 				}
 			}
-			o.Metrics = spec
+			t.Metrics = spec
 		case "traces":
-			spec := &ObservabilityTracesSpec{}
+			spec := &TelemetryTracesSpec{}
 			if valNode.Tag != "!!null" {
 				if err := valNode.Decode(spec); err != nil {
-					return fmt.Errorf("observability.traces: %w", err)
+					return fmt.Errorf("telemetry.traces: %w", err)
 				}
 			}
-			o.Traces = spec
+			t.Traces = spec
 		}
 	}
 	return nil
 }
 
 type SettingsSpec struct {
-	Proxy         ProxySpec         `yaml:"proxy,omitempty"`
-	Observability ObservabilitySpec `yaml:"observability,omitempty"`
+	Proxy     ProxySpec     `yaml:"proxy,omitempty"`
+	Telemetry TelemetrySpec `yaml:"telemetry,omitempty"`
+}
+
+// UnmarshalYAML rejects the removed observability key explicitly. yaml.v3's
+// default struct decoder ignores unknown fields, which would otherwise turn an
+// old config into a silently disabled telemetry pipeline.
+func (s *SettingsSpec) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind == yaml.MappingNode {
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			if node.Content[i].Value == "observability" {
+				return fmt.Errorf("settings.observability was renamed to settings.telemetry")
+			}
+		}
+	}
+
+	type plain SettingsSpec
+	var decoded plain
+	if err := node.Decode(&decoded); err != nil {
+		return fmt.Errorf("settings: %w", err)
+	}
+	*s = SettingsSpec(decoded)
+	return nil
 }
 
 // ── upstreams ──
@@ -438,13 +459,13 @@ func consumerQuotas(q ConsumerQuotasSpec) []storage.CreateConsumerQuota {
 	return out
 }
 
-// flattenSettings expands the nested settings.proxy/observability YAML
+// flattenSettings expands the nested settings.proxy/telemetry YAML
 // shape into the dot-key rows SettingsStore persists. proxy.* uses its own
-// dot-key namespace. observability.* maps onto the
+// dot-key namespace. telemetry.* maps onto the
 // obs_<signal>_exporter / obs_<signal>_<engine>_<field> keys
 // internal/telemetry's LoadConfig consumes, validated against the exporter
 // registry (internal/telemetry/schema.ExportersFor) as described on
-// flattenObservabilitySignal.
+// flattenTelemetrySignal.
 func flattenSettings(s SettingsSpec) (map[string]string, error) {
 	out := map[string]string{}
 	setIfNonEmpty := func(key, value string) {
@@ -470,9 +491,9 @@ func flattenSettings(s SettingsSpec) (map[string]string, error) {
 	// closed, no obs_<signal>_* keys produced (LoadConfig treats a missing
 	// obs_<signal>_exporter as disabled). A non-nil block is present in the
 	// YAML — even if written as `logs: {}` — and must declare an exporter;
-	// flattenObservabilitySignal errors otherwise.
-	if l := s.Observability.Logs; l != nil {
-		if err := flattenObservabilitySignal(out, schema.SignalLogs, l.Exporter, map[string]string{
+	// flattenTelemetrySignal errors otherwise.
+	if l := s.Telemetry.Logs; l != nil {
+		if err := flattenTelemetrySignal(out, schema.SignalLogs, l.Exporter, map[string]string{
 			"endpoint": l.Endpoint,
 			"protocol": l.Protocol,
 			"interval": l.Interval,
@@ -480,8 +501,8 @@ func flattenSettings(s SettingsSpec) (map[string]string, error) {
 			return nil, err
 		}
 	}
-	if m := s.Observability.Metrics; m != nil {
-		if err := flattenObservabilitySignal(out, schema.SignalMetrics, m.Exporter, map[string]string{
+	if m := s.Telemetry.Metrics; m != nil {
+		if err := flattenTelemetrySignal(out, schema.SignalMetrics, m.Exporter, map[string]string{
 			"endpoint": m.Endpoint,
 			"protocol": m.Protocol,
 			"interval": m.Interval,
@@ -491,8 +512,8 @@ func flattenSettings(s SettingsSpec) (map[string]string, error) {
 			return nil, err
 		}
 	}
-	if t := s.Observability.Traces; t != nil {
-		if err := flattenObservabilitySignal(out, schema.SignalTraces, t.Exporter, map[string]string{
+	if t := s.Telemetry.Traces; t != nil {
+		if err := flattenTelemetrySignal(out, schema.SignalTraces, t.Exporter, map[string]string{
 			"endpoint": t.Endpoint,
 			"protocol": t.Protocol,
 			"interval": t.Interval,
@@ -504,7 +525,7 @@ func flattenSettings(s SettingsSpec) (map[string]string, error) {
 	return out, nil
 }
 
-// flattenObservabilitySignal validates and flattens one present observability
+// flattenTelemetrySignal validates and flattens one present telemetry
 // signal block into obs_<signal>_exporter plus one obs_<signal>_<exporter>_
 // <field> key per non-empty field. fields is keyed by FieldDef.Name (e.g.
 // "endpoint", "listen") — every key present in fields with a non-empty value
@@ -516,10 +537,10 @@ func flattenSettings(s SettingsSpec) (map[string]string, error) {
 // exporterName == "" means the block was present in YAML but never set
 // exporter (e.g. `logs: {}`) — always an error, since a present block must
 // pick an engine.
-func flattenObservabilitySignal(out map[string]string, signal schema.Signal, exporterName string, fields map[string]string) error {
+func flattenTelemetrySignal(out map[string]string, signal schema.Signal, exporterName string, fields map[string]string) error {
 	name := string(signal)
 	if exporterName == "" {
-		return fmt.Errorf("observability.%s: exporter is required when the block is present", name)
+		return fmt.Errorf("telemetry.%s: exporter is required when the block is present", name)
 	}
 
 	defs := schema.ExportersFor(signal)
@@ -531,7 +552,7 @@ func flattenObservabilitySignal(out map[string]string, signal schema.Signal, exp
 		}
 	}
 	if def == nil {
-		return fmt.Errorf("observability.%s: unknown exporter %q", name, exporterName)
+		return fmt.Errorf("telemetry.%s: unknown exporter %q", name, exporterName)
 	}
 
 	allowed := make(map[string]bool, len(def.Fields))
@@ -545,7 +566,7 @@ func flattenObservabilitySignal(out map[string]string, signal schema.Signal, exp
 			continue
 		}
 		if !allowed[field] {
-			return fmt.Errorf("observability.%s: field %q is not valid for exporter %q", name, field, exporterName)
+			return fmt.Errorf("telemetry.%s: field %q is not valid for exporter %q", name, field, exporterName)
 		}
 		out[fmt.Sprintf("obs_%s_%s_%s", name, exporterName, field)] = value
 	}

--- a/go/internal/config/config_test.go
+++ b/go/internal/config/config_test.go
@@ -19,7 +19,7 @@ settings:
     request_timeout: "45s"
     max_retries: 3
     max_body_bytes: 1048576
-  observability:
+  telemetry:
     logs:
       exporter: stdout
 upstreams:
@@ -107,7 +107,7 @@ consumers:
 		t.Error("explicit token not discoverable after ApplyTo")
 	}
 
-	// settings flattened: proxy.* stored verbatim, observability.* mapped onto obs_* keys.
+	// settings flattened: proxy.* stored verbatim, telemetry.* mapped onto obs_* keys.
 	if v, _ := core.Settings().Get("proxy.request_timeout"); v != "45s" {
 		t.Errorf("proxy.request_timeout = %q, want 45s", v)
 	}
@@ -398,9 +398,9 @@ func TestConsumerQuotas_ExpandsAllCategories(t *testing.T) {
 func TestFlattenSettings(t *testing.T) {
 	s := SettingsSpec{
 		Proxy: ProxySpec{RequestTimeout: "120s", MaxRetries: 2, RetryOnStatus: []int{429, 500}, MaxBodyBytes: 1048576},
-		Observability: ObservabilitySpec{
-			Logs:   &ObservabilityLogsSpec{Exporter: "stdout"},
-			Traces: &ObservabilityTracesSpec{Exporter: "otlp", Endpoint: "http://127.0.0.1:4317", Protocol: "grpc"},
+		Telemetry: TelemetrySpec{
+			Logs:   &TelemetryLogsSpec{Exporter: "stdout"},
+			Traces: &TelemetryTracesSpec{Exporter: "otlp", Endpoint: "http://127.0.0.1:4317", Protocol: "grpc"},
 		},
 	}
 	got, err := flattenSettings(s)
@@ -426,7 +426,7 @@ func TestFlattenSettings(t *testing.T) {
 	// Metrics block absent entirely: no obs_metrics_* key of any kind.
 	for k := range got {
 		if strings.HasPrefix(k, "obs_metrics_") {
-			t.Errorf("unset observability.metrics block should not appear in flattened settings, got key %q", k)
+			t.Errorf("unset telemetry.metrics block should not appear in flattened settings, got key %q", k)
 		}
 	}
 	for k := range got {
@@ -444,8 +444,8 @@ func TestFlattenSettings(t *testing.T) {
 
 func TestFlattenSettings_MetricsPrometheusListenAndPath(t *testing.T) {
 	s := SettingsSpec{
-		Observability: ObservabilitySpec{
-			Metrics: &ObservabilityMetricsSpec{Exporter: "prometheus", Listen: ":9464", Path: "/metrics"},
+		Telemetry: TelemetrySpec{
+			Metrics: &TelemetryMetricsSpec{Exporter: "prometheus", Listen: ":9464", Path: "/metrics"},
 		},
 	}
 	got, err := flattenSettings(s)
@@ -465,7 +465,7 @@ func TestFlattenSettings_MetricsPrometheusListenAndPath(t *testing.T) {
 }
 
 func TestFlattenSettings_BlockAbsent_SilentlyClosed(t *testing.T) {
-	// No observability block at all: zero value ObservabilitySpec has all
+	// No telemetry block at all: zero value TelemetrySpec has all
 	// three pointers nil.
 	got, err := flattenSettings(SettingsSpec{})
 	if err != nil {
@@ -473,27 +473,31 @@ func TestFlattenSettings_BlockAbsent_SilentlyClosed(t *testing.T) {
 	}
 	for k := range got {
 		if strings.HasPrefix(k, "obs_") {
-			t.Errorf("no observability blocks present, but got obs key %q", k)
+			t.Errorf("no telemetry blocks present, but got obs key %q", k)
 		}
 	}
 }
 
 func TestFlattenSettings_BlockPresentMissingExporter_Errors(t *testing.T) {
 	s := SettingsSpec{
-		Observability: ObservabilitySpec{
-			Logs: &ObservabilityLogsSpec{}, // present (non-nil) but no exporter set
+		Telemetry: TelemetrySpec{
+			Logs: &TelemetryLogsSpec{}, // present (non-nil) but no exporter set
 		},
 	}
-	if _, err := flattenSettings(s); err == nil {
+	_, err := flattenSettings(s)
+	if err == nil {
 		t.Fatal("expected error for logs block present without exporter, got nil")
+	}
+	if !strings.Contains(err.Error(), "telemetry.logs: exporter is required") {
+		t.Fatalf("flattenSettings error = %q, want telemetry.logs path", err)
 	}
 }
 
 func TestFlattenSettings_FieldNotBelongingToExporter_Errors(t *testing.T) {
 	s := SettingsSpec{
-		Observability: ObservabilitySpec{
+		Telemetry: TelemetrySpec{
 			// stdout has no endpoint field.
-			Logs: &ObservabilityLogsSpec{Exporter: "stdout", Endpoint: "http://127.0.0.1:4317"},
+			Logs: &TelemetryLogsSpec{Exporter: "stdout", Endpoint: "http://127.0.0.1:4317"},
 		},
 	}
 	if _, err := flattenSettings(s); err == nil {
@@ -503,18 +507,22 @@ func TestFlattenSettings_FieldNotBelongingToExporter_Errors(t *testing.T) {
 
 func TestFlattenSettings_UnknownExporter_Errors(t *testing.T) {
 	s := SettingsSpec{
-		Observability: ObservabilitySpec{
-			Traces: &ObservabilityTracesSpec{Exporter: "graphite"},
+		Telemetry: TelemetrySpec{
+			Traces: &TelemetryTracesSpec{Exporter: "graphite"},
 		},
 	}
-	if _, err := flattenSettings(s); err == nil {
+	_, err := flattenSettings(s)
+	if err == nil {
 		t.Fatal("expected error for unregistered exporter kind, got nil")
+	}
+	if !strings.Contains(err.Error(), `telemetry.traces: unknown exporter "graphite"`) {
+		t.Fatalf("flattenSettings error = %q, want telemetry.traces path", err)
 	}
 }
 
 // writeAndLoadYAML writes body to a temp nyro.yaml and loads it through the
 // real LoadYAML path (env-var expansion + yaml.v3 unmarshal), returning the
-// flattened settings map. Used by the observability presence/absence tests
+// flattened settings map. Used by the telemetry presence/absence tests
 // below so the presence-vs-null distinction is exercised through actual YAML
 // parsing rather than constructed Go struct literals.
 func writeAndLoadYAML(t *testing.T, body string) (map[string]string, error) {
@@ -531,46 +539,46 @@ func writeAndLoadYAML(t *testing.T, body string) (map[string]string, error) {
 	return flattenSettings(cfg.Settings)
 }
 
-func TestLoadYAML_ObservabilityBlockAbsent_SilentlyClosed(t *testing.T) {
+func TestLoadYAML_TelemetryBlockAbsent_SilentlyClosed(t *testing.T) {
 	got, err := writeAndLoadYAML(t, "version: 1\n")
 	if err != nil {
 		t.Fatalf("flattenSettings: %v", err)
 	}
 	for k := range got {
 		if strings.HasPrefix(k, "obs_") {
-			t.Errorf("observability block absent from YAML, but got obs key %q", k)
+			t.Errorf("telemetry block absent from YAML, but got obs key %q", k)
 		}
 	}
 }
 
-func TestLoadYAML_ObservabilityLogsEmptyMapping_Errors(t *testing.T) {
-	_, err := writeAndLoadYAML(t, "version: 1\nsettings:\n  observability:\n    logs: {}\n")
+func TestLoadYAML_TelemetryLogsEmptyMapping_Errors(t *testing.T) {
+	_, err := writeAndLoadYAML(t, "version: 1\nsettings:\n  telemetry:\n    logs: {}\n")
 	if err == nil {
 		t.Fatal("expected error for `logs: {}` (present, no exporter), got nil")
 	}
 }
 
-func TestLoadYAML_ObservabilityLogsBareNullKey_Errors(t *testing.T) {
+func TestLoadYAML_TelemetryLogsBareNullKey_Errors(t *testing.T) {
 	// Bare `logs:` with no value decodes as a YAML null scalar. It must be
 	// treated as "block present but empty" (same as `logs: {}`), not "block
 	// absent" — this is the regression the reviewer flagged.
-	_, err := writeAndLoadYAML(t, "version: 1\nsettings:\n  observability:\n    logs:\n")
+	_, err := writeAndLoadYAML(t, "version: 1\nsettings:\n  telemetry:\n    logs:\n")
 	if err == nil {
 		t.Fatal("expected error for bare `logs:` (null, present) missing exporter, got nil")
 	}
 }
 
-func TestLoadYAML_ObservabilityLogsNullWithComment_Errors(t *testing.T) {
+func TestLoadYAML_TelemetryLogsNullWithComment_Errors(t *testing.T) {
 	// `logs:\n  # nothing here\n` also decodes as a null scalar for the logs
 	// key (the comment carries no YAML content) — must error the same way.
-	_, err := writeAndLoadYAML(t, "version: 1\nsettings:\n  observability:\n    logs:\n      # nothing here\n")
+	_, err := writeAndLoadYAML(t, "version: 1\nsettings:\n  telemetry:\n    logs:\n      # nothing here\n")
 	if err == nil {
 		t.Fatal("expected error for `logs:` with only a comment (null, present) missing exporter, got nil")
 	}
 }
 
-func TestLoadYAML_ObservabilityLogsWithExporter_Succeeds(t *testing.T) {
-	got, err := writeAndLoadYAML(t, "version: 1\nsettings:\n  observability:\n    logs:\n      exporter: stdout\n")
+func TestLoadYAML_TelemetryLogsWithExporter_Succeeds(t *testing.T) {
+	got, err := writeAndLoadYAML(t, "version: 1\nsettings:\n  telemetry:\n    logs:\n      exporter: stdout\n")
 	if err != nil {
 		t.Fatalf("flattenSettings: %v", err)
 	}
@@ -579,13 +587,30 @@ func TestLoadYAML_ObservabilityLogsWithExporter_Succeeds(t *testing.T) {
 	}
 }
 
-func TestLoadYAML_ObservabilityMetricsPrometheus_Succeeds(t *testing.T) {
+func TestLoadYAML_ObservabilityKeyRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nyro.yaml")
+	body := "version: 1\nsettings:\n  observability:\n    logs:\n      exporter: stdout\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := LoadYAML(path)
+	if err == nil {
+		t.Fatal("expected settings.observability to be rejected")
+	}
+	if !strings.Contains(err.Error(), "settings.observability was renamed to settings.telemetry") {
+		t.Fatalf("LoadYAML error = %q, want rename guidance", err)
+	}
+}
+
+func TestLoadYAML_TelemetryMetricsPrometheus_Succeeds(t *testing.T) {
 	// Real YAML round-trip for metrics+prometheus (listen+path), matching the
 	// shape documented in docs/schema/config.md. Existing coverage exercised
 	// prometheus fields only via a constructed SettingsSpec literal
 	// (TestFlattenSettings_MetricsPrometheusListenAndPath) and exercised real
 	// YAML parsing only for logs+stdout — this closes that gap.
-	got, err := writeAndLoadYAML(t, "version: 1\nsettings:\n  observability:\n    metrics:\n      exporter: prometheus\n      listen: \":9464\"\n      path: \"/metrics\"\n")
+	got, err := writeAndLoadYAML(t, "version: 1\nsettings:\n  telemetry:\n    metrics:\n      exporter: prometheus\n      listen: \":9464\"\n      path: \"/metrics\"\n")
 	if err != nil {
 		t.Fatalf("flattenSettings: %v", err)
 	}

--- a/go/internal/config/doc.go
+++ b/go/internal/config/doc.go
@@ -3,14 +3,14 @@
 // admin/DB.
 //
 // The YAML shape mirrors the config-schema plan's final config.yaml: version +
-// settings (server/proxy/observability) + upstreams + routes + consumers
+// settings (server/proxy/telemetry) + upstreams + routes + consumers
 // (nested keys/routes/quotas).
 //
 // Layer: 1 (data) — may import internal/config/snapshot,
 // internal/protocol/llm, layer 0, and storage.
 //
 // It imports telemetry/schema (layer 0) for the exporter registry used to
-// validate the settings.observability.* YAML block. It does not import the
+// validate the settings.telemetry.* YAML block. It does not import the
 // telemetry runtime.
 //
 // Must not import layer 3 (proxy, router, admin, dataplane, bootstrap).

--- a/go/internal/gateway/runtime/runtime.go
+++ b/go/internal/gateway/runtime/runtime.go
@@ -91,7 +91,7 @@ func Build(ctx context.Context, opts Options) (*gateway.Gateway, *ObsManager, er
 	switch {
 	case opts.ConfigPath != "":
 		// Standalone YAML: build the config snapshot directly (no DB). The
-		// observability config comes from settings.observability in the YAML
+		// observability config comes from settings.telemetry in the YAML
 		// file (flattened into the snapshot by internal/config); if the file
 		// declares nothing, defaults are logs→stdout, metrics/traces→disabled.
 		// See resolveObsConfig — environment variables are never consulted.

--- a/go/internal/gateway/runtime/runtime_test.go
+++ b/go/internal/gateway/runtime/runtime_test.go
@@ -70,19 +70,19 @@ consumers:
 	}
 }
 
-// TestBuild_StandaloneReadsObservabilityFromYAML proves settings.observability
+// TestBuild_StandaloneReadsTelemetryFromYAML proves settings.telemetry
 // declared in the YAML file actually reaches the observability provider (it did
 // not before this fix — standalone mode read OTEL_* env vars only and silently
 // ignored the file). traces.exporter: otlp with no endpoint anywhere must trip
 // NewProvider's fail-fast guard — that failure is only possible if the YAML
 // setting was actually read.
-func TestBuild_StandaloneReadsObservabilityFromYAML(t *testing.T) {
+func TestBuild_StandaloneReadsTelemetryFromYAML(t *testing.T) {
 	dir := t.TempDir()
 	path := dir + "/nyro.yaml"
 	const yaml = `
 version: 1
 settings:
-  observability:
+  telemetry:
     traces:
       exporter: otlp
 upstreams: []


### PR DESCRIPTION
BREAKING CHANGE: standalone configs must replace settings.observability with settings.telemetry.