### PR TITLE
feat(llm): add weighted backend routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2994,6 +2994,7 @@ dependencies = [
  "nyro-limit",
  "nyro-protocol",
  "nyro-security",
+ "rand 0.8.6",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Claude Code · Codex CLI · Gemini CLI · OpenCode
 
 Nyro ships as a **desktop app** (macOS / Windows / Linux) and a **standalone server binary** for headless and self-hosted deployments.
 
-An experimental new Rust `nyro proxy` data plane is also available for source builds. It has its own strict file format and currently supports OpenAI Chat/Embedding, stateless Responses, and Anthropic/Gemini Chat subsets; see the [Rust file-config proxy guide](docs/standalone/rust-proxy.md). Released `nyro-server` commands and configuration remain unchanged.
+An experimental new Rust `nyro proxy` data plane is also available for source builds. It has its own strict file format and currently supports OpenAI Chat/Embedding, stateless Responses, and Anthropic/Gemini Chat subsets, with weighted selection across compatible backends; see the [Rust file-config proxy guide](docs/standalone/rust-proxy.md). Released `nyro-server` commands and configuration remain unchanged.
 
 ---
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -43,7 +43,7 @@ Claude Code · Codex CLI · Gemini CLI · OpenCode
 
 Nyro 同时提供 **桌面应用**（macOS / Windows / Linux）和 **独立服务端二进制**，适用于无头部署与自托管场景。
 
-源码中另有实验性的新 Rust `nyro proxy` 数据面，使用独立的严格文件格式，目前支持 OpenAI Chat/Embedding、无状态 Responses 及 Anthropic/Gemini Chat 子集；详见 [Rust 文件配置代理指南](docs/standalone/rust-proxy_CN.md)。已发布 `nyro-server` 的命令和配置保持不变。
+源码中另有实验性的新 Rust `nyro proxy` 数据面，使用独立的严格文件格式，目前支持 OpenAI Chat/Embedding、无状态 Responses 及 Anthropic/Gemini Chat 子集，并支持在兼容的 backend 间加权选择；详见 [Rust 文件配置代理指南](docs/standalone/rust-proxy_CN.md)。已发布 `nyro-server` 的命令和配置保持不变。
 
 ---
 

--- a/crates/nyro-config/src/lib.rs
+++ b/crates/nyro-config/src/lib.rs
@@ -182,6 +182,7 @@ impl Config {
             .sort_by(|left, right| (&left.id, &left.secret).cmp(&(&right.id, &right.secret)));
         for model in canonical.llm.models.values_mut() {
             model.workloads.sort();
+            model.backends.sort_by(|left, right| left.id.cmp(&right.id));
         }
         for provider in canonical.llm.providers.values_mut() {
             if provider.api == Some(nyro_llm::config::OpenAiApi::ChatCompletions) {

--- a/crates/nyro-config/tests/config.rs
+++ b/crates/nyro-config/tests/config.rs
@@ -1,7 +1,7 @@
 use nyro_config::{Config, LimitConfig, SecurityConfig, ServerConfig};
 use nyro_llm::{
     Workload,
-    config::{Config as LlmConfig, Model, Provider, ProviderKind},
+    config::{Backend, Config as LlmConfig, Model, Provider, ProviderKind},
 };
 use nyro_security::ApiKey;
 use std::{
@@ -26,8 +26,12 @@ fn valid_config() -> Config {
             models: BTreeMap::from([(
                 "chat".into(),
                 Model {
-                    provider: "openai".into(),
-                    upstream_model: "gpt-example".into(),
+                    backends: vec![Backend {
+                        id: "default".into(),
+                        provider: "openai".into(),
+                        upstream_model: "gpt-example".into(),
+                        weight: 100,
+                    }],
                     workloads: vec![Workload::Chat, Workload::Embedding],
                     allow_anonymous: false,
                     subjects: BTreeSet::from(["deploy".into()]),
@@ -274,5 +278,71 @@ fn debug_and_validation_errors_do_not_expose_secrets() {
     for secret in ["provider-secret", "client-secret", "url-secret"] {
         assert!(!debug.contains(secret));
         assert!(!error.contains(secret));
+    }
+}
+
+fn yaml_with_routing(routing: &str) -> String {
+    format!(
+        "llm:\n  providers:\n    p: {{kind: openai, base_url: https://example.test}}\n    q: {{kind: openai, base_url: https://second.example.test}}\n  models:\n    chat:\n      workloads: [chat]\n      allow_anonymous: true\n{routing}\n"
+    )
+}
+
+#[test]
+fn yaml_legacy_and_explicit_default_backend_have_the_same_fingerprint() {
+    let legacy = Config::from_yaml(&yaml_with_routing(
+        "      provider: p\n      upstream_model: u",
+    ))
+    .unwrap();
+    let canonical = Config::from_yaml(&yaml_with_routing(
+        "      backends:\n        - {id: default, provider: p, upstream_model: u}",
+    ))
+    .expect("canonical backend YAML must load");
+    assert_eq!(
+        legacy.fingerprint().unwrap(),
+        canonical.fingerprint().unwrap()
+    );
+}
+
+#[test]
+fn fingerprint_ignores_backend_order_and_retains_every_backend_setting() {
+    let first = Config::from_yaml(&yaml_with_routing(
+        "      backends:\n        - {id: primary, provider: p, upstream_model: u, weight: 80}\n        - {id: secondary, provider: q, upstream_model: v, weight: 0}"
+    )).unwrap();
+    let reordered = Config::from_yaml(&yaml_with_routing(
+        "      backends:\n        - {id: secondary, provider: q, upstream_model: v, weight: 0}\n        - {id: primary, provider: p, upstream_model: u, weight: 80}"
+    )).unwrap();
+    assert_eq!(
+        first.fingerprint().unwrap(),
+        reordered.fingerprint().unwrap()
+    );
+    for changed_backend in [
+        "{id: renamed, provider: q, upstream_model: v, weight: 0}",
+        "{id: secondary, provider: p, upstream_model: v, weight: 0}",
+        "{id: secondary, provider: q, upstream_model: different, weight: 0}",
+        "{id: secondary, provider: q, upstream_model: v, weight: 1}",
+    ] {
+        let changed = Config::from_yaml(&yaml_with_routing(&format!(
+            "      backends:\n        - {{id: primary, provider: p, upstream_model: u, weight: 80}}\n        - {changed_backend}"
+        ))).unwrap();
+        assert_ne!(first.fingerprint().unwrap(), changed.fingerprint().unwrap());
+    }
+}
+
+#[test]
+fn yaml_rejects_ambiguous_or_invalid_backend_routes() {
+    for routing in [
+        "      backends: null",
+        "      backends: []",
+        "      provider: p\n      upstream_model: u\n      backends: null",
+        "      provider: null\n      backends: [{id: b, provider: p, upstream_model: u}]",
+        "      backends: [{id: b, provider: p, upstream_model: u, weight: -1}]",
+        "      backends: [{id: b, provider: p, upstream_model: u, weight: 4294967296}]",
+        "      backends: [{id: b, provider: p, upstream_model: u, weight: 0}]",
+        "      backends: [{id: b, provider: p, upstream_model: u}, {id: b, provider: p, upstream_model: v}]",
+    ] {
+        assert!(
+            Config::from_yaml(&yaml_with_routing(routing)).is_err(),
+            "{routing}"
+        );
     }
 }

--- a/crates/nyro-llm/Cargo.toml
+++ b/crates/nyro-llm/Cargo.toml
@@ -19,6 +19,7 @@ reqwest.workspace = true
 tracing.workspace = true
 futures = "0.3"
 bytes = "1"
+rand = "0.8"
 
 [dev-dependencies]
 tracing-subscriber.workspace = true

--- a/crates/nyro-llm/src/config.rs
+++ b/crates/nyro-llm/src/config.rs
@@ -51,16 +51,77 @@ impl std::fmt::Debug for Provider {
     }
 }
 
+#[derive(Clone, Debug, Serialize)]
+pub struct Model {
+    pub backends: Vec<Backend>,
+    pub workloads: Vec<Workload>,
+    pub allow_anonymous: bool,
+    pub subjects: BTreeSet<String>,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct Model {
+pub struct Backend {
+    pub id: String,
     pub provider: String,
     pub upstream_model: String,
-    pub workloads: Vec<Workload>,
+    #[serde(default = "default_weight")]
+    pub weight: u32,
+}
+
+const fn default_weight() -> u32 {
+    100
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawModel {
+    #[serde(default, deserialize_with = "present")]
+    backends: Option<Vec<Backend>>,
+    #[serde(default, deserialize_with = "present")]
+    provider: Option<String>,
+    #[serde(default, deserialize_with = "present")]
+    upstream_model: Option<String>,
+    workloads: Vec<Workload>,
     #[serde(default)]
-    pub allow_anonymous: bool,
+    allow_anonymous: bool,
     #[serde(default)]
-    pub subjects: BTreeSet<String>,
+    subjects: BTreeSet<String>,
+}
+
+// Missing routing fields are allowed here; explicitly null fields are not.
+fn present<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    T::deserialize(deserializer).map(Some)
+}
+
+impl<'de> Deserialize<'de> for Model {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = RawModel::deserialize(deserializer)?;
+        let backends = match (raw.backends, raw.provider, raw.upstream_model) {
+            (Some(backends), None, None) => backends,
+            (None, Some(provider), Some(upstream_model)) => vec![Backend {
+                id: "default".into(),
+                provider,
+                upstream_model,
+                weight: default_weight(),
+            }],
+            _ => {
+                return Err(serde::de::Error::custom(
+                    "model must define either backends or provider and upstream_model",
+                ));
+            }
+        };
+        Ok(Self {
+            backends,
+            workloads: raw.workloads,
+            allow_anonymous: raw.allow_anonymous,
+            subjects: raw.subjects,
+        })
+    }
 }
 
 #[derive(Debug, Error)]
@@ -79,6 +140,14 @@ pub enum ConfigError {
     InvalidProviderApi { provider: String },
     #[error("model ID must not be empty")]
     EmptyModelId,
+    #[error("model `{model}` must define at least one backend")]
+    NoBackends { model: String },
+    #[error("model `{model}` has an empty backend ID")]
+    EmptyBackendId { model: String },
+    #[error("model `{model}` contains duplicate backend ID `{backend}`")]
+    DuplicateBackendId { model: String, backend: String },
+    #[error("model `{model}` must have a positive total backend weight within u64 bounds")]
+    InvalidBackendWeight { model: String },
     #[error("model `{model}` references unknown provider `{provider}`")]
     UnknownProvider { model: String, provider: String },
     #[error("model `{model}` must define an upstream model")]
@@ -144,36 +213,57 @@ impl Config {
             if id.trim().is_empty() {
                 return Err(ConfigError::EmptyModelId);
             }
-            if !self.providers.contains_key(&model.provider) {
-                return Err(ConfigError::UnknownProvider {
-                    model: id.clone(),
-                    provider: model.provider.clone(),
-                });
+            if model.backends.is_empty() {
+                return Err(ConfigError::NoBackends { model: id.clone() });
             }
-            if model.upstream_model.trim().is_empty() {
-                return Err(ConfigError::EmptyUpstreamModel { model: id.clone() });
-            }
-            let provider = &self.providers[&model.provider];
-            let kind = provider.kind;
-            if (kind != ProviderKind::Openai || provider.api == Some(OpenAiApi::Responses))
-                && model.workloads.contains(&Workload::Embedding)
-            {
-                return Err(ConfigError::UnsupportedWorkload { model: id.clone() });
-            }
-            if kind == ProviderKind::Gemini {
-                let name = model
-                    .upstream_model
-                    .strip_prefix("models/")
-                    .unwrap_or(&model.upstream_model);
-                if name.is_empty()
-                    || name == "."
-                    || name == ".."
-                    || !name
-                        .bytes()
-                        .all(|b| b.is_ascii_alphanumeric() || b"-_.".contains(&b))
-                {
-                    return Err(ConfigError::InvalidGeminiModel { model: id.clone() });
+            let mut backend_ids = BTreeSet::new();
+            let mut total_weight = 0u64;
+            for backend in &model.backends {
+                if backend.id.trim().is_empty() {
+                    return Err(ConfigError::EmptyBackendId { model: id.clone() });
                 }
+                if !backend_ids.insert(&backend.id) {
+                    return Err(ConfigError::DuplicateBackendId {
+                        model: id.clone(),
+                        backend: backend.id.clone(),
+                    });
+                }
+                total_weight = total_weight
+                    .checked_add(u64::from(backend.weight))
+                    .ok_or_else(|| ConfigError::InvalidBackendWeight { model: id.clone() })?;
+                let provider = self.providers.get(&backend.provider).ok_or_else(|| {
+                    ConfigError::UnknownProvider {
+                        model: id.clone(),
+                        provider: backend.provider.clone(),
+                    }
+                })?;
+                if backend.upstream_model.trim().is_empty() {
+                    return Err(ConfigError::EmptyUpstreamModel { model: id.clone() });
+                }
+                let kind = provider.kind;
+                if (kind != ProviderKind::Openai || provider.api == Some(OpenAiApi::Responses))
+                    && model.workloads.contains(&Workload::Embedding)
+                {
+                    return Err(ConfigError::UnsupportedWorkload { model: id.clone() });
+                }
+                if kind == ProviderKind::Gemini {
+                    let name = backend
+                        .upstream_model
+                        .strip_prefix("models/")
+                        .unwrap_or(&backend.upstream_model);
+                    if name.is_empty()
+                        || name == "."
+                        || name == ".."
+                        || !name
+                            .bytes()
+                            .all(|b| b.is_ascii_alphanumeric() || b"-_.".contains(&b))
+                    {
+                        return Err(ConfigError::InvalidGeminiModel { model: id.clone() });
+                    }
+                }
+            }
+            if total_weight == 0 {
+                return Err(ConfigError::InvalidBackendWeight { model: id.clone() });
             }
             if model.workloads.is_empty() {
                 return Err(ConfigError::NoWorkloads { model: id.clone() });

--- a/crates/nyro-llm/src/lib.rs
+++ b/crates/nyro-llm/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod config;
 mod ingress;
 mod provider;
+mod router;
 pub mod runtime;
 
 pub mod codec;

--- a/crates/nyro-llm/src/router.rs
+++ b/crates/nyro-llm/src/router.rs
@@ -1,0 +1,46 @@
+//! One weighted choice; request preparation decides which backends are eligible.
+use rand::{
+    Rng,
+    distributions::{Distribution, WeightedIndex},
+};
+
+pub(crate) fn choose(weights: impl IntoIterator<Item = u32>) -> Option<usize> {
+    choose_with(weights, &mut rand::thread_rng())
+}
+
+fn choose_with(weights: impl IntoIterator<Item = u32>, rng: &mut impl Rng) -> Option<usize> {
+    WeightedIndex::new(weights.into_iter().map(u64::from))
+        .ok()
+        .map(|distribution| distribution.sample(rng))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::{SeedableRng, rngs::StdRng};
+
+    #[test]
+    fn excludes_disabled_backends_and_handles_empty_candidates() {
+        let mut rng = StdRng::seed_from_u64(42);
+        assert_eq!(choose_with([], &mut rng), None);
+        assert_eq!(choose_with([0, 0], &mut rng), None);
+        for _ in 0..100 {
+            assert_eq!(choose_with([0, 100, 0], &mut rng), Some(1));
+        }
+    }
+
+    #[test]
+    fn weights_change_selection_probability_without_u32_sum_overflow() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut selected = [0; 2];
+        for _ in 0..10_000 {
+            selected[choose_with([1, 9], &mut rng).unwrap()] += 1;
+        }
+        assert!((8500..9500).contains(&selected[1]), "{selected:?}");
+        let mut seen = [false; 2];
+        for _ in 0..100 {
+            seen[choose_with([u32::MAX, u32::MAX], &mut rng).unwrap()] = true;
+        }
+        assert_eq!(seen, [true, true]);
+    }
+}

--- a/crates/nyro-llm/src/runtime.rs
+++ b/crates/nyro-llm/src/runtime.rs
@@ -19,6 +19,7 @@ use crate::{
     config,
     ingress::body::{self, Outcome},
     provider::Driver,
+    router,
 };
 
 mod endpoint;
@@ -118,6 +119,7 @@ impl Runtime {
         let mut exchange = Exchange {
             started,
             model: None,
+            backend: None,
             permit: None,
             status: None,
             outcome: Outcome::Cancelled,
@@ -146,6 +148,54 @@ impl Runtime {
         )
     }
 
+    /// Preparation is local and side-effect free: incompatible codecs never get a network attempt.
+    fn select_backend<'a>(
+        &'a self,
+        model: &'a config::Model,
+        request: &Request,
+        downstream: ChatFormat,
+    ) -> Result<Prepared<'a>, Failure> {
+        let mut eligible = Vec::new();
+        for backend in model.backends.iter().filter(|backend| backend.weight > 0) {
+            let provider = self
+                .providers
+                .get(&backend.provider)
+                .ok_or_else(Failure::upstream)?;
+            let mut request = request.clone();
+            request.set_model(backend.upstream_model.clone());
+            if provider.format == ChatFormat::OpenAiChat
+                && let Request::Chat(chat) = &mut request
+            {
+                if downstream == ChatFormat::OpenAiResponses {
+                    chat.openai.store = Some(false);
+                }
+                if chat.stream == Some(true) && downstream != ChatFormat::OpenAiChat {
+                    chat.openai
+                        .stream_options
+                        .get_or_insert(nyro_protocol::openai::chat::StreamOptions {
+                            include_usage: None,
+                            include_obfuscation: None,
+                        })
+                        .include_usage = Some(true);
+                }
+            }
+            if let Ok(encoded) = provider.encode(&request) {
+                eligible.push(Prepared {
+                    backend,
+                    provider,
+                    request,
+                    encoded,
+                });
+            }
+        }
+        let index = router::choose(eligible.iter().map(|candidate| candidate.backend.weight))
+            .ok_or_else(|| {
+                Failure::invalid("Request cannot be represented by any enabled backend")
+            })?;
+        // Drop every unselected request and encoded body before sending upstream.
+        Ok(eligible.swap_remove(index))
+    }
+
     async fn execute(
         &self,
         request: HttpRequest<Body>,
@@ -169,7 +219,7 @@ impl Runtime {
         }
         let value: Value =
             serde_json::from_slice(&input).map_err(|_| Failure::invalid("Invalid JSON request"))?;
-        let mut request = endpoint.decode(value)?;
+        let request = endpoint.decode(value)?;
         let public_model = request.model().to_owned();
         exchange.model = Some(public_model.clone());
         // Resolve -> Authenticate -> Authorize -> Admit are mandatory ordinary runtime steps.
@@ -209,34 +259,14 @@ impl Runtime {
         })?);
         let streaming = request.is_streaming();
         let include_usage = matches!(&request, Request::Chat(chat) if chat.openai.stream_options.as_ref().is_some_and(|options| options.include_usage == Some(true)));
-        request.set_model(model.upstream_model.clone());
-        let provider = self
-            .providers
-            .get(&model.provider)
-            .ok_or_else(Failure::upstream)?;
-        // Preserve the stateless Responses contract when translating to Chat Completions.
-        if provider.format == ChatFormat::OpenAiChat
-            && endpoint.format == ChatFormat::OpenAiResponses
-            && let Request::Chat(chat) = &mut request
-        {
-            chat.openai.store = Some(false);
-        }
-        if streaming
-            && provider.format == ChatFormat::OpenAiChat
-            && endpoint.format != ChatFormat::OpenAiChat
-            && let Request::Chat(chat) = &mut request
-        {
-            chat.openai
-                .stream_options
-                .get_or_insert(nyro_protocol::openai::chat::StreamOptions {
-                    include_usage: None,
-                    include_obfuscation: None,
-                })
-                .include_usage = Some(true);
-        }
-        let encoded = provider.encode(&request).map_err(|_| {
-            Failure::invalid("Request cannot be represented by the configured provider")
-        })?;
+        let selected = self.select_backend(model, &request, endpoint.format)?;
+        exchange.backend = Some(selected.backend.id.clone());
+        let Prepared {
+            request,
+            provider,
+            encoded,
+            ..
+        } = selected;
         let response = provider
             .send(&request, &encoded)
             .await
@@ -335,9 +365,17 @@ impl Runtime {
     }
 }
 
+struct Prepared<'a> {
+    backend: &'a config::Backend,
+    provider: &'a Driver,
+    request: Request,
+    encoded: Value,
+}
+
 struct Exchange {
     started: Instant,
     model: Option<String>,
+    backend: Option<String>,
     permit: Option<Permit>,
     status: Option<StatusCode>,
     outcome: Outcome,
@@ -351,7 +389,7 @@ impl Exchange {
 
 impl Drop for Exchange {
     fn drop(&mut self) {
-        tracing::info!(target: "nyro::request", model = self.model.as_deref().unwrap_or(""), status = self.status.map_or(0, |status| status.as_u16()),
+        tracing::info!(target: "nyro::request", model = self.model.as_deref().unwrap_or(""), backend = self.backend.as_deref().unwrap_or(""), status = self.status.map_or(0, |status| status.as_u16()),
             duration_ms = self.started.elapsed().as_millis() as u64, outcome = ?self.outcome, "LLM request finished");
         // This slice owns only synchronous finalization; the permit releases after observation.
     }

--- a/crates/nyro-llm/tests/config.rs
+++ b/crates/nyro-llm/tests/config.rs
@@ -1,6 +1,6 @@
 use nyro_llm::{
     Workload,
-    config::{Config, Model, Provider, ProviderKind},
+    config::{Backend, Config, Model, Provider, ProviderKind},
 };
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -18,8 +18,12 @@ fn valid_config() -> Config {
         models: BTreeMap::from([(
             "chat".into(),
             Model {
-                provider: "openai".into(),
-                upstream_model: "gpt-example".into(),
+                backends: vec![Backend {
+                    id: "default".into(),
+                    provider: "openai".into(),
+                    upstream_model: "gpt-example".into(),
+                    weight: 100,
+                }],
                 workloads: vec![Workload::Chat],
                 allow_anonymous: false,
                 subjects: BTreeSet::from(["deploy".into()]),
@@ -78,14 +82,11 @@ fn validation_rejects_empty_names_workloads_duplicates_and_missing_references() 
     assert!(config.validate().is_err());
 
     let mut config = valid_config();
-    config.models.get_mut("chat").unwrap().provider = "missing".into();
+    config.models.get_mut("chat").unwrap().backends[0].provider = "missing".into();
     assert!(config.validate().is_err());
 
     let mut config = valid_config();
-    config
-        .models
-        .get_mut("chat")
-        .unwrap()
+    config.models.get_mut("chat").unwrap().backends[0]
         .upstream_model
         .clear();
     assert!(config.validate().is_err());
@@ -156,4 +157,133 @@ fn api_selector_is_openai_only_and_responses_is_chat_only() {
     assert!(config.validate().is_ok());
     value["providers"]["openai"]["api"] = "unknown".into();
     assert!(serde_json::from_value::<Config>(value).is_err());
+}
+
+#[test]
+fn canonical_backends_and_legacy_models_share_one_serialized_contract() {
+    let legacy: Model = serde_json::from_value(serde_json::json!({
+        "provider": "p", "upstream_model": "upstream", "workloads": ["chat"]
+    }))
+    .unwrap();
+    let canonical: Model = serde_json::from_value(serde_json::json!({
+        "backends": [{"id": "default", "provider": "p", "upstream_model": "upstream"}],
+        "workloads": ["chat"]
+    }))
+    .expect("canonical backends must deserialize");
+    let serialized = serde_json::to_value(canonical).unwrap();
+    assert_eq!(serialized, serde_json::to_value(legacy).unwrap());
+    assert_eq!(serialized["backends"][0]["weight"], 100);
+    assert!(serialized.get("provider").is_none());
+    assert!(serialized.get("upstream_model").is_none());
+}
+
+#[test]
+fn routing_deserialization_rejects_missing_mixed_null_and_unknown_fields() {
+    let backend = serde_json::json!({"id": "b", "provider": "p", "upstream_model": "u"});
+    for routing in [
+        serde_json::json!({}),
+        serde_json::json!({"provider": "p"}),
+        serde_json::json!({"upstream_model": "u"}),
+        serde_json::json!({"provider": null, "upstream_model": "u"}),
+        serde_json::json!({"provider": "p", "upstream_model": null}),
+        serde_json::json!({"backends": null}),
+        serde_json::json!({"backends": [backend.clone()], "provider": "p"}),
+        serde_json::json!({"backends": [backend.clone()], "upstream_model": "u"}),
+        serde_json::json!({"backends": [backend.clone()], "provider": null}),
+        serde_json::json!({"backends": [backend.clone()], "upstream_model": null}),
+        serde_json::json!({"backends": null, "provider": "p", "upstream_model": "u"}),
+        serde_json::json!({"backends": [backend], "priority": 1}),
+    ] {
+        let mut value = routing;
+        value["workloads"] = serde_json::json!(["chat"]);
+        assert!(
+            serde_json::from_value::<Model>(value.clone()).is_err(),
+            "{value}"
+        );
+    }
+    for field in ["weight", "priority"] {
+        for value in [
+            serde_json::json!(-1),
+            serde_json::json!(4294967296u64),
+            serde_json::Value::Null,
+        ] {
+            let mut backend =
+                serde_json::json!({"id": "b", "provider": "p", "upstream_model": "u"});
+            backend[field] = value;
+            assert!(
+                serde_json::from_value::<Model>(serde_json::json!({
+                    "backends": [backend], "workloads": ["chat"]
+                }))
+                .is_err()
+            );
+        }
+    }
+}
+
+#[test]
+fn backend_validation_rejects_empty_duplicate_disabled_and_unknown_targets() {
+    let backend = serde_json::json!({"id": "primary", "provider": "openai", "upstream_model": "u", "weight": 100});
+    for backends in [
+        serde_json::json!([]),
+        serde_json::json!([backend.clone(), backend.clone()]),
+        serde_json::json!([{ "id": " ", "provider": "openai", "upstream_model": "u" }]),
+        serde_json::json!([{ "id": "b", "provider": "openai", "upstream_model": " " }]),
+        serde_json::json!([{ "id": "b", "provider": "missing", "upstream_model": "u" }]),
+        serde_json::json!([{ "id": "b", "provider": "openai", "upstream_model": "u", "weight": 0 }]),
+        serde_json::json!([backend.clone(), { "id": "disabled", "provider": "missing", "upstream_model": "u", "weight": 0 }]),
+        serde_json::json!([backend, { "id": "disabled", "provider": "openai", "upstream_model": " ", "weight": 0 }]),
+    ] {
+        let mut value = serde_json::to_value(valid_config()).unwrap();
+        value["models"]["chat"] = serde_json::json!({"backends": backends, "workloads": ["chat"]});
+        let config: Config = serde_json::from_value(value).expect("structurally valid model");
+        assert!(config.validate().is_err());
+    }
+}
+
+#[test]
+fn disabled_backends_must_support_every_declared_workload_and_valid_model_names() {
+    for (kind, api, workloads, upstream_model) in [
+        (
+            "anthropic",
+            None,
+            serde_json::json!(["chat", "embedding"]),
+            "u",
+        ),
+        ("gemini", None, serde_json::json!(["embedding"]), "u"),
+        (
+            "openai",
+            Some("responses"),
+            serde_json::json!(["embedding"]),
+            "u",
+        ),
+        ("gemini", None, serde_json::json!(["chat"]), "models/../bad"),
+    ] {
+        let mut value = serde_json::to_value(valid_config()).unwrap();
+        value["providers"]["disabled"] =
+            serde_json::json!({"kind": kind, "api": api, "base_url": "https://example.test"});
+        value["models"]["chat"] = serde_json::json!({
+            "backends": [
+                {"id": "primary", "provider": "openai", "upstream_model": "u"},
+                {"id": "disabled", "provider": "disabled", "upstream_model": upstream_model, "weight": 0}
+            ], "workloads": workloads
+        });
+        let config: Config = serde_json::from_value(value).unwrap();
+        assert!(config.validate().is_err(), "{kind} {api:?}");
+    }
+}
+
+#[test]
+fn backend_ids_are_model_scoped_and_large_weight_totals_are_valid() {
+    let mut value = serde_json::to_value(valid_config()).unwrap();
+    let model = serde_json::json!({
+        "backends": [
+            {"id": "primary", "provider": "openai", "upstream_model": "u", "weight": 4294967295u32},
+            {"id": "secondary", "provider": "openai", "upstream_model": "v", "weight": 4294967295u32},
+            {"id": "disabled", "provider": "openai", "upstream_model": "w", "weight": 0}
+        ], "workloads": ["chat"]
+    });
+    value["models"]["chat"] = model.clone();
+    value["models"]["another"] = model;
+    let config: Config = serde_json::from_value(value).unwrap();
+    assert!(config.validate().is_ok());
 }

--- a/crates/nyro-llm/tests/routing_runtime.rs
+++ b/crates/nyro-llm/tests/routing_runtime.rs
@@ -1,0 +1,664 @@
+//! Multi-backend behavior against independent loopback wire fixtures.
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use axum::{
+    Router,
+    body::{Body, to_bytes},
+    http::{Request, Response, StatusCode},
+    routing::post,
+};
+use futures::StreamExt;
+use nyro_limit::ConcurrencyLimit;
+use nyro_llm::{
+    config::Config,
+    runtime::{Options, Runtime},
+};
+use nyro_security::{ApiKey, ApiKeys};
+use serde_json::{Value, json};
+use tokio_util::sync::CancellationToken;
+
+#[test]
+fn canonical_routing_configuration_is_accepted() {
+    let config = serde_json::from_value::<Config>(json!({
+        "providers":{"p":{"kind":"openai","base_url":"http://127.0.0.1:1/v1"}},
+        "models":{"public":{"backends":[{"id":"primary","provider":"p","upstream_model":"private"}],"workloads":["chat"]}}
+    }));
+    assert!(config.is_ok(), "{config:?}");
+}
+
+struct Upstream {
+    base: String,
+    format: &'static str,
+    calls: Arc<Mutex<Vec<Value>>>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl Upstream {
+    fn count(&self) -> usize {
+        self.calls.lock().unwrap().len()
+    }
+}
+
+impl Drop for Upstream {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+// Fixtures deliberately contain upstream aliases and never invoke the codecs under test.
+fn answer(format: &str, tools: bool) -> Value {
+    match format {
+        "openai" => json!({
+            "id":"route-answer","object":"chat.completion","created":7,"model":"upstream-private",
+            "choices":[{"index":0,"message":if tools {
+                json!({"role":"assistant","content":null,"tool_calls":[{"id":"call-route","type":"function","function":{"name":"lookup","arguments":"{\"city\":\"Paris\"}"}}]})
+            } else { json!({"role":"assistant","content":"Routed hello"}) },
+            "finish_reason":if tools { "tool_calls" } else { "stop" }}],
+            "usage":{"prompt_tokens":4,"completion_tokens":2,"total_tokens":6}
+        }),
+        "anthropic" => json!({
+            "id":"route-answer","type":"message","role":"assistant","model":"upstream-private",
+            "content":if tools { json!([{"type":"tool_use","id":"call-route","name":"lookup","input":{"city":"Paris"}}]) }
+                else { json!([{"type":"text","text":"Routed hello"}]) },
+            "stop_reason":if tools { "tool_use" } else { "end_turn" },"stop_sequence":null,
+            "usage":{"input_tokens":4,"output_tokens":2}
+        }),
+        "gemini" => json!({
+            "responseId":"route-answer","modelVersion":"upstream-private",
+            "candidates":[{"index":0,"content":{"role":"model","parts":if tools {
+                json!([{"functionCall":{"id":"call-route","name":"lookup","args":{"city":"Paris"}}}])
+            } else { json!([{"text":"Routed hello"}]) }},"finishReason":"STOP"}],
+            "usageMetadata":{"promptTokenCount":4,"candidatesTokenCount":2,"totalTokenCount":6}
+        }),
+        _ => unreachable!(),
+    }
+}
+
+fn frames(format: &str, tools: bool, complete: bool) -> String {
+    let payload = answer(format, tools);
+    match format {
+        "openai" => {
+            let delta = if tools {
+                json!({"role":"assistant","tool_calls":[{"index":0,"id":"call-route","type":"function","function":{"name":"lookup","arguments":"{\"city\":\"Paris\"}"}}]})
+            } else {
+                json!({"role":"assistant","content":"Routed hello"})
+            };
+            let first = json!({"id":"route-answer","object":"chat.completion.chunk","created":7,"model":"upstream-private","choices":[{"index":0,"delta":delta,"finish_reason":null}]});
+            let mut text = format!("data: {first}\n\n");
+            if complete {
+                let last = json!({"id":"route-answer","object":"chat.completion.chunk","created":7,"model":"upstream-private","choices":[{"index":0,"delta":{},"finish_reason":if tools {"tool_calls"} else {"stop"}}],"usage":{"prompt_tokens":4,"completion_tokens":2,"total_tokens":6}});
+                text.push_str(&format!("data: {last}\n\ndata: [DONE]\n\n"));
+            }
+            text
+        }
+        "anthropic" => {
+            let mut start = payload.clone();
+            start["content"] = json!([]);
+            start["stop_reason"] = Value::Null;
+            start["usage"]["output_tokens"] = json!(0);
+            let (block, delta) = if tools {
+                (
+                    json!({"type":"tool_use","id":"call-route","name":"lookup","input":{}}),
+                    json!({"type":"input_json_delta","partial_json":"{\"city\":\"Paris\"}"}),
+                )
+            } else {
+                (
+                    json!({"type":"text","text":""}),
+                    json!({"type":"text_delta","text":"Routed hello"}),
+                )
+            };
+            let mut events = vec![
+                json!({"type":"message_start","message":start}),
+                json!({"type":"content_block_start","index":0,"content_block":block}),
+                json!({"type":"content_block_delta","index":0,"delta":delta}),
+            ];
+            if complete {
+                events.extend([
+                    json!({"type":"content_block_stop","index":0}),
+                    json!({"type":"message_delta","delta":{"stop_reason":payload["stop_reason"],"stop_sequence":null},"usage":{"output_tokens":2}}),
+                    json!({"type":"message_stop"}),
+                ]);
+            }
+            events
+                .iter()
+                .map(|event| {
+                    format!(
+                        "event: {}\ndata: {event}\n\n",
+                        event["type"].as_str().unwrap()
+                    )
+                })
+                .collect()
+        }
+        "gemini" => format!("data: {payload}\n\n"),
+        _ => unreachable!(),
+    }
+}
+
+async fn upstream(format: &'static str, mode: &'static str) -> Upstream {
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let observed = calls.clone();
+    let app = Router::new().fallback(post(move |request: Request<Body>| {
+        let observed = observed.clone();
+        async move {
+            let path = request.uri().to_string();
+            let headers: BTreeMap<_, _> = request.headers().iter()
+                .map(|(name, value)| (name.to_string(), value.to_str().unwrap().to_owned())).collect();
+            let body: Value = serde_json::from_slice(&to_bytes(request.into_body(), 1024 * 1024).await.unwrap()).unwrap();
+            let streaming = body["stream"] == true || path.contains(":streamGenerateContent");
+            observed.lock().unwrap().push(json!({"path":path,"headers":headers,"body":body}));
+            if mode == "slow" {
+                tokio::time::sleep(Duration::from_secs(30)).await;
+            }
+            if mode == "error" {
+                return Response::builder().status(503).body(Body::from("private failure secret")).unwrap();
+            }
+            if streaming {
+                let text = if mode == "bad" { "data: {broken-json}\n\n".into() }
+                    else { frames(format, mode == "tools", !matches!(mode, "truncated" | "hang")) };
+                let chunks: Vec<_> = text.into_bytes().chunks(11)
+                    .map(|chunk| Ok::<_, std::io::Error>(chunk.to_vec())).collect();
+                let stream = futures::stream::iter(chunks);
+                let stream = if mode == "hang" { stream.chain(futures::stream::pending()).boxed() } else { stream.boxed() };
+                return Response::builder().header("content-type", "text/event-stream").body(Body::from_stream(stream)).unwrap();
+            }
+            let payload = if path.ends_with("/embeddings") {
+                json!({"object":"list","model":"upstream-private","data":[{"object":"embedding","index":0,"embedding":[0.1,0.9]}],"usage":{"prompt_tokens":4,"total_tokens":4}})
+            } else { answer(format, mode == "tools") };
+            Response::builder().header("content-type", "application/json").body(Body::from(payload.to_string())).unwrap()
+        }
+    }));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!(
+        "http://{}/{}",
+        listener.local_addr().unwrap(),
+        if format == "gemini" { "v1beta" } else { "v1" }
+    );
+    let task = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    Upstream {
+        base,
+        format,
+        calls,
+        task,
+    }
+}
+
+fn configuration(upstreams: &[&Upstream], weights: &[u32], workloads: &[&str]) -> Config {
+    let mut providers = serde_json::Map::new();
+    let mut backends = Vec::new();
+    for (index, (upstream, weight)) in upstreams.iter().zip(weights).enumerate() {
+        let id = format!("provider-{index}");
+        providers.insert(id.clone(), json!({"kind":upstream.format,"base_url":upstream.base,"api_key":format!("provider-secret-{index}")}));
+        backends.push(json!({"id":format!("backend-{index}"),"provider":id,"upstream_model":format!("private-{index}"),"weight":weight}));
+    }
+    serde_json::from_value(json!({"providers":providers,"models":{"public":{"backends":backends,"workloads":workloads,"subjects":["alice"]}}})).unwrap()
+}
+
+fn keys() -> Arc<ApiKeys> {
+    Arc::new(
+        ApiKeys::new(vec![
+            ApiKey {
+                id: "alice".into(),
+                secret: "client-secret".into(),
+            },
+            ApiKey {
+                id: "bob".into(),
+                secret: "bob-secret".into(),
+            },
+        ])
+        .unwrap(),
+    )
+}
+
+fn runtime(config: Config, limit: &ConcurrencyLimit, options: Options) -> Runtime {
+    Runtime::new(config, keys(), limit.clone(), options).unwrap()
+}
+
+fn request(path: &str, body: Value, credential: Option<&str>) -> Request<Body> {
+    let mut request = Request::builder()
+        .method("POST")
+        .uri(path)
+        .header("content-type", "application/json");
+    if let Some(key) = credential {
+        request = request.header("authorization", format!("Bearer {key}"));
+    }
+    request.body(Body::from(body.to_string())).unwrap()
+}
+
+fn chat(streaming: bool, tools: bool) -> Value {
+    let mut body = json!({"model":"public","messages":[{"role":"user","content":"Where?"}],"stream":streaming});
+    if tools {
+        body["tools"] = json!([{"type":"function","function":{"name":"lookup","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}]);
+        body["messages"].as_array_mut().unwrap().extend([
+            json!({"role":"assistant","tool_calls":[{"id":"call-before","type":"function","function":{"name":"lookup","arguments":"{\"city\":\"Rome\"}"}}]}),
+            json!({"role":"tool","tool_call_id":"call-before","content":"{\"weather\":\"sunny\"}"}),
+        ]);
+    }
+    body
+}
+
+async fn invoke(runtime: &Runtime, body: Value) -> Response<Body> {
+    runtime
+        .handle(
+            request("/v1/chat/completions", body, Some("client-secret")),
+            CancellationToken::new(),
+        )
+        .await
+}
+
+fn assert_wire(call: &Value, format: &str, index: usize, streaming: bool) {
+    let path = match format {
+        "openai" => "/v1/chat/completions".into(),
+        "anthropic" => "/v1/messages".into(),
+        "gemini" => format!(
+            "/v1beta/models/private-{index}:{}",
+            if streaming {
+                "streamGenerateContent?alt=sse"
+            } else {
+                "generateContent"
+            }
+        ),
+        _ => unreachable!(),
+    };
+    assert_eq!(call["path"], path);
+    let headers = &call["headers"];
+    let (name, secret) = match format {
+        "openai" => ("authorization", format!("Bearer provider-secret-{index}")),
+        "anthropic" => ("x-api-key", format!("provider-secret-{index}")),
+        "gemini" => ("x-goog-api-key", format!("provider-secret-{index}")),
+        _ => unreachable!(),
+    };
+    assert_eq!(headers[name], secret);
+    assert!(!headers.to_string().contains("client-secret"));
+    for other in ["authorization", "x-api-key", "x-goog-api-key"] {
+        if other != name {
+            assert!(headers.get(other).is_none());
+        }
+    }
+    if format == "anthropic" {
+        assert_eq!(headers["anthropic-version"], "2023-06-01");
+    }
+    if format != "gemini" {
+        assert_eq!(call["body"]["model"], format!("private-{index}"));
+    }
+}
+
+#[tokio::test]
+async fn zero_weight_backends_are_never_called_and_selected_protocol_owns_the_wire() {
+    for tools in [false, true] {
+        let mode = if tools { "tools" } else { "normal" };
+        let openai = upstream("openai", mode).await;
+        let anthropic = upstream("anthropic", mode).await;
+        let gemini = upstream("gemini", mode).await;
+        let upstreams = [&openai, &anthropic, &gemini];
+        for selected in 0..3 {
+            let mut weights = [0; 3];
+            weights[selected] = 1;
+            let limit = ConcurrencyLimit::new(1).unwrap();
+            let runtime = runtime(
+                configuration(&upstreams, &weights, &["chat"]),
+                &limit,
+                Options::default(),
+            );
+            for streaming in [false, true] {
+                let before: Vec<_> = upstreams.iter().map(|upstream| upstream.count()).collect();
+                let mut input = chat(streaming, tools);
+                input["max_tokens"] = json!(32);
+                let result = invoke(&runtime, input).await;
+                assert_eq!(
+                    result.status(),
+                    StatusCode::OK,
+                    "selected={selected}, tools={tools}, streaming={streaming}"
+                );
+                assert_eq!(limit.available(), 0);
+                let output = to_bytes(result.into_body(), 16384).await.unwrap();
+                let output = String::from_utf8(output.to_vec()).unwrap();
+                assert!(output.contains("public"), "{output}");
+                assert!(!output.contains("upstream-private"));
+                if tools {
+                    assert!(
+                        output.contains("lookup")
+                            && output.contains("call-route")
+                            && output.contains("Paris"),
+                        "{output}"
+                    );
+                } else {
+                    assert!(output.contains("Routed hello"));
+                }
+                if streaming {
+                    assert_eq!(output.matches("[DONE]").count(), 1);
+                }
+                assert_eq!(limit.available(), 1);
+                for (index, upstream) in upstreams.iter().enumerate() {
+                    assert_eq!(
+                        upstream.count(),
+                        before[index] + usize::from(index == selected)
+                    );
+                }
+                let calls = upstreams[selected].calls.lock().unwrap();
+                let call = calls.last().unwrap();
+                assert_wire(call, upstreams[selected].format, selected, streaming);
+                if tools {
+                    let body = call["body"].to_string();
+                    assert!(
+                        body.contains("call-before")
+                            && body.contains("lookup")
+                            && body.contains("sunny"),
+                        "{body}"
+                    );
+                    assert!(call["body"]["tools"].is_array());
+                }
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn request_compatibility_filters_high_weight_backend_before_dispatch() {
+    for tools in [false, true] {
+        let mode = if tools { "tools" } else { "normal" };
+        let anthropic = upstream("anthropic", mode).await;
+        let openai = upstream("openai", mode).await;
+        let limit = ConcurrencyLimit::new(1).unwrap();
+        let runtime = runtime(
+            configuration(&[&anthropic, &openai], &[u32::MAX, 1], &["chat"]),
+            &limit,
+            Options::default(),
+        );
+        // Both backends are enabled. Only Anthropic requires explicit max_tokens.
+        for streaming in [false, true] {
+            let response = invoke(&runtime, chat(streaming, tools)).await;
+            assert_eq!(response.status(), StatusCode::OK);
+            let body = to_bytes(response.into_body(), 16384).await.unwrap();
+            assert!(String::from_utf8_lossy(&body).contains(if tools {
+                "lookup"
+            } else {
+                "Routed hello"
+            }));
+            assert_eq!(limit.available(), 1);
+            assert_eq!(anthropic.count(), 0);
+        }
+        let calls = openai.calls.lock().unwrap();
+        assert_eq!(calls.len(), 2);
+        for (index, call) in calls.iter().enumerate() {
+            assert_wire(call, "openai", 1, index == 1);
+        }
+    }
+}
+
+#[tokio::test]
+async fn embedding_uses_one_backend_and_restores_public_alias() {
+    let disabled = upstream("openai", "normal").await;
+    let selected = upstream("openai", "normal").await;
+    let limit = ConcurrencyLimit::new(1).unwrap();
+    let runtime = runtime(
+        configuration(&[&disabled, &selected], &[0, 100], &["chat", "embedding"]),
+        &limit,
+        Options::default(),
+    );
+    let response = runtime
+        .handle(
+            request(
+                "/v1/embeddings",
+                json!({"model":"public","input":["alpha","beta"]}),
+                Some("client-secret"),
+            ),
+            CancellationToken::new(),
+        )
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value =
+        serde_json::from_slice(&to_bytes(response.into_body(), 16384).await.unwrap()).unwrap();
+    assert_eq!(body["model"], "public");
+    assert_eq!(body["data"][0]["embedding"], json!([0.1, 0.9]));
+    assert_eq!(limit.available(), 1);
+    assert_eq!(disabled.count(), 0);
+    let calls = selected.calls.lock().unwrap();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0]["path"], "/v1/embeddings");
+    assert_eq!(
+        calls[0]["headers"]["authorization"],
+        "Bearer provider-secret-1"
+    );
+    assert_eq!(calls[0]["body"]["model"], "private-1");
+    assert_eq!(calls[0]["body"]["input"], json!(["alpha", "beta"]));
+}
+
+#[tokio::test]
+async fn responses_ingress_keeps_stateless_chat_payload_and_stream_usage_after_filtering() {
+    let anthropic = upstream("anthropic", "normal").await;
+    let openai = upstream("openai", "normal").await;
+    let limit = ConcurrencyLimit::new(1).unwrap();
+    let runtime = runtime(
+        configuration(&[&anthropic, &openai], &[u32::MAX, 1], &["chat"]),
+        &limit,
+        Options::default(),
+    );
+    for streaming in [false, true] {
+        let response = runtime
+            .handle(
+                request(
+                    "/v1/responses",
+                    json!({"model":"public","input":"Where?","stream":streaming,"store":false}),
+                    Some("client-secret"),
+                ),
+                CancellationToken::new(),
+            )
+            .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), 16384).await.unwrap();
+        let output = String::from_utf8_lossy(&bytes);
+        assert!(output.contains("public") && output.contains("Routed hello"));
+        if streaming {
+            let terminal = output
+                .lines()
+                .filter_map(|line| line.strip_prefix("data: "))
+                .map(|data| serde_json::from_str::<Value>(data).unwrap())
+                .find(|event| event["type"] == "response.completed")
+                .unwrap();
+            assert_eq!(terminal["response"]["usage"]["total_tokens"], 6);
+        }
+        assert_eq!(limit.available(), 1);
+    }
+    assert_eq!(anthropic.count(), 0);
+    let calls = openai.calls.lock().unwrap();
+    assert_eq!(calls.len(), 2);
+    for (index, call) in calls.iter().enumerate() {
+        assert_wire(call, "openai", 1, index == 1);
+        assert_eq!(call["body"]["store"], false);
+    }
+    assert_eq!(calls[1]["body"]["stream_options"]["include_usage"], true);
+}
+
+#[tokio::test]
+async fn no_compatible_backend_returns_sanitized_400_without_dispatch() {
+    let first = upstream("anthropic", "normal").await;
+    let second = upstream("anthropic", "normal").await;
+    let limit = ConcurrencyLimit::new(1).unwrap();
+    let runtime = runtime(
+        configuration(&[&first, &second], &[1, 100], &["chat"]),
+        &limit,
+        Options::default(),
+    );
+    let response = invoke(&runtime, chat(false, false)).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = to_bytes(response.into_body(), 16384).await.unwrap();
+    let body = String::from_utf8_lossy(&body);
+    assert!(!body.contains("private-") && !body.contains("secret"));
+    assert_eq!(first.count() + second.count(), 0);
+    assert_eq!(limit.available(), 1);
+}
+
+#[tokio::test]
+async fn disabled_incompatible_workloads_still_fail_startup() {
+    let openai = upstream("openai", "normal").await;
+    let anthropic = upstream("anthropic", "normal").await;
+    let limit = ConcurrencyLimit::new(1).unwrap();
+    for weight in [0, 1] {
+        let config = configuration(
+            &[&openai, &anthropic],
+            &[100, weight],
+            &["chat", "embedding"],
+        );
+        assert!(Runtime::new(config, keys(), limit.clone(), Options::default()).is_err());
+    }
+    assert_eq!(openai.count() + anthropic.count(), 0);
+}
+
+#[tokio::test]
+async fn authentication_authorization_and_admission_deny_before_dispatch() {
+    let first = upstream("openai", "normal").await;
+    let second = upstream("openai", "normal").await;
+    let limit = ConcurrencyLimit::new(1).unwrap();
+    let runtime = runtime(
+        configuration(&[&first, &second], &[1, 1], &["chat"]),
+        &limit,
+        Options::default(),
+    );
+    for (credential, status) in [(None, 401), (Some("wrong"), 401), (Some("bob-secret"), 403)] {
+        let response = runtime
+            .handle(
+                request("/v1/chat/completions", chat(false, false), credential),
+                CancellationToken::new(),
+            )
+            .await;
+        assert_eq!(response.status().as_u16(), status);
+        drop(response);
+        assert_eq!(limit.available(), 1);
+    }
+    let permit = limit.try_acquire().unwrap();
+    let response = invoke(&runtime, chat(false, false)).await;
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    drop(response);
+    assert_eq!(first.count() + second.count(), 0);
+    drop(permit);
+    assert_eq!(limit.available(), 1);
+}
+
+#[tokio::test]
+async fn selected_failure_and_invalid_streams_never_attempt_an_enabled_alternative() {
+    for (mode, status) in [("error", 503), ("bad", 502), ("truncated", 200)] {
+        // Equal behavior makes the assertion deterministic whichever backend is chosen.
+        let first = upstream("openai", mode).await;
+        let second = upstream("openai", mode).await;
+        let limit = ConcurrencyLimit::new(1).unwrap();
+        let runtime = runtime(
+            configuration(&[&first, &second], &[1, 1], &["chat"]),
+            &limit,
+            Options::default(),
+        );
+        let response = invoke(&runtime, chat(mode != "error", false)).await;
+        assert_eq!(response.status().as_u16(), status, "{mode}");
+        let body = to_bytes(response.into_body(), 16384).await;
+        if mode == "truncated" {
+            assert!(body.is_err());
+        } else {
+            assert!(!String::from_utf8_lossy(&body.unwrap()).contains("private failure"));
+        }
+        assert_eq!(first.count() + second.count(), 1, "{mode}");
+        assert_eq!(limit.available(), 1);
+    }
+}
+
+#[tokio::test]
+async fn stream_cancel_drop_and_whole_request_deadline_release_admission_without_retry() {
+    for action in ["cancel", "drop", "deadline"] {
+        let first = upstream("openai", "hang").await;
+        let second = upstream("openai", "hang").await;
+        let limit = ConcurrencyLimit::new(1).unwrap();
+        let options = Options {
+            request_timeout: Duration::from_millis(300),
+            ..Options::default()
+        };
+        let runtime = runtime(
+            configuration(&[&first, &second], &[1, 1], &["chat"]),
+            &limit,
+            options,
+        );
+        let cancellation = CancellationToken::new();
+        let response = runtime
+            .handle(
+                request(
+                    "/v1/chat/completions",
+                    chat(true, false),
+                    Some("client-secret"),
+                ),
+                cancellation.clone(),
+            )
+            .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(limit.available(), 0);
+        match action {
+            "drop" => drop(response),
+            "cancel" => {
+                cancellation.cancel();
+                assert!(to_bytes(response.into_body(), 16384).await.is_err());
+            }
+            "deadline" => {
+                let result = tokio::time::timeout(
+                    Duration::from_secs(2),
+                    to_bytes(response.into_body(), 16384),
+                )
+                .await
+                .unwrap();
+                assert!(result.is_err());
+            }
+            _ => unreachable!(),
+        }
+        assert_eq!(limit.available(), 1, "{action}");
+        assert_eq!(first.count() + second.count(), 1, "{action}");
+    }
+}
+
+#[tokio::test]
+async fn pre_header_cancellation_drop_and_deadline_release_admission_without_retry() {
+    for action in ["cancel", "drop", "deadline"] {
+        let first = upstream("openai", "slow").await;
+        let second = upstream("openai", "slow").await;
+        let limit = ConcurrencyLimit::new(1).unwrap();
+        let runtime = runtime(
+            configuration(&[&first, &second], &[1, 1], &["chat"]),
+            &limit,
+            Options {
+                request_timeout: Duration::from_millis(300),
+                ..Options::default()
+            },
+        );
+        let cancellation = CancellationToken::new();
+        let mut pending = Box::pin(runtime.handle(
+            request(
+                "/v1/chat/completions",
+                chat(false, false),
+                Some("client-secret"),
+            ),
+            cancellation.clone(),
+        ));
+        tokio::select! {
+            _ = &mut pending => panic!("fixture must remain pending before response headers"),
+            result = tokio::time::timeout(Duration::from_secs(2), async {
+                while first.count() + second.count() == 0 { tokio::task::yield_now().await; }
+            }) => result.unwrap(),
+        }
+        assert_eq!(limit.available(), 0);
+        if action == "drop" {
+            drop(pending);
+        } else {
+            if action == "cancel" {
+                cancellation.cancel();
+            }
+            let response = tokio::time::timeout(Duration::from_secs(2), pending)
+                .await
+                .unwrap();
+            assert_eq!(
+                response.status().as_u16(),
+                if action == "cancel" { 503 } else { 504 }
+            );
+            drop(response);
+        }
+        assert_eq!(limit.available(), 1, "{action}");
+        assert_eq!(first.count() + second.count(), 1, "{action}");
+    }
+}

--- a/crates/nyro-llm/tests/runtime.rs
+++ b/crates/nyro-llm/tests/runtime.rs
@@ -88,8 +88,12 @@ fn runtime(upstream: &Upstream, limit: ConcurrencyLimit, options: Options) -> Ru
         models: BTreeMap::from([(
             "public-model".into(),
             config::Model {
-                provider: "upstream".into(),
-                upstream_model: "internal-model".into(),
+                backends: vec![config::Backend {
+                    id: "default".into(),
+                    provider: "upstream".into(),
+                    upstream_model: "internal-model".into(),
+                    weight: 100,
+                }],
                 workloads: vec![Workload::Chat, Workload::Embedding],
                 allow_anonymous: false,
                 subjects: ["alice".into()].into(),

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -4,7 +4,7 @@
 >
 > 本文是本轮 Rust 重构的目标架构依据，不代表代码已完成迁移。目录树、Rust 类型示例和命令形态均为目标设计；当前实现请查看[现有 workspace](../../Cargo.toml)和本文的现状对应表。
 
-当前已落地独立的 [`nyro-kernel`](../../crates/nyro-kernel/README_CN.md)，以及使用它的实验性源码构建根命令 [`nyro proxy --config`](../standalone/rust-proxy_CN.md)。该命令实现严格文件配置、OpenAI Chat/Embedding、无状态 Responses、Anthropic/Gemini Chat 与跨协议 SSE 子集、认证授权、共享并发限制和代际 lease。现有 `nyro-core`、已发布 Server 和 Tauri 请求路径尚未接入该内核；`nyro serve`、`nyro tool`、控制面和其余目标能力仍未实现。
+当前已落地独立的 [`nyro-kernel`](../../crates/nyro-kernel/README_CN.md)，以及使用它的实验性源码构建根命令 [`nyro proxy --config`](../standalone/rust-proxy_CN.md)。该命令实现严格文件配置、OpenAI Chat/Embedding、无状态 Responses、Anthropic/Gemini Chat 与跨协议 SSE 子集、多 backend 加权选择、认证授权、共享并发限制和代际 lease。现有 `nyro-core`、已发布 Server 和 Tauri 请求路径尚未接入该内核；`nyro serve`、`nyro tool`、控制面和其余目标能力仍未实现。
 
 ## 1. 产品定位与范围
 
@@ -425,6 +425,8 @@ HTTP 基础接入
 ```
 
 接入层先完成与代际无关的基础解析；依赖配置的解码、能力选择和后续执行使用同一个代际。认证身份、截止时间、路由结果、尝试状态和原始传输信息放在请求执行上下文，不扩散为每个 IR 的通用业务字段。
+
+当前已实现模型范围内带稳定 ID 的 backend 列表与加权单次选择：认证和准入之后，在本地按各 backend 的 codec 准备请求，仅在可表达该请求的启用项之间按权重选择；没有候选时返回请求错误。旧单上游 YAML 在解析时归一化，列表顺序不影响配置指纹。优先级、健康状态、重试和故障转移仍未实现。
 
 LLM runtime 掌握必需阶段顺序、最终路由选择、重试预算、流提交状态及终态交付。可选扩展只能在声明槽位继续、拒绝或短路；提前产生结果仍由 runtime 完成协议交付和收尾。扩展不能跳过认证、授权或准入，不能自行调用下一阶段、发送上游请求或写入客户端响应，也不能取消已登记的 Finalizers。
 

--- a/docs/standalone/rust-proxy.md
+++ b/docs/standalone/rust-proxy.md
@@ -23,7 +23,7 @@ curl http://127.0.0.1:19530/v1/chat/completions \
   -d '{"model":"chat-default","messages":[{"role":"user","content":"Hello"}]}'
 ```
 
-The current ingress implements typed subsets of OpenAI Chat/Embedding, stateless Responses, Anthropic Messages, and Gemini generateContent. Chat supports cross-protocol text, function calls/results and SSE across the four supported Chat API formats. It is not a promise of full vendor API compatibility. Unknown or unsupported request fields are rejected with `400` instead of being forwarded. Unsupported upstream response semantics produce `502` before streaming begins, or terminate an SSE stream if they arrive after its validated first frame. Model names are public aliases: Nyro replaces them with `upstream_model` on the upstream request and restores the public name in supported responses.
+The current ingress implements typed subsets of OpenAI Chat/Embedding, stateless Responses, Anthropic Messages, and Gemini generateContent. Chat supports cross-protocol text, function calls/results and SSE across the four supported Chat API formats. It is not a promise of full vendor API compatibility. Unknown or unsupported request fields are rejected with `400` instead of being forwarded. Unsupported upstream response semantics produce `502` before streaming begins, or terminate an SSE stream if they arrive after its validated first frame. Model names are public aliases: Nyro replaces them with the selected backend's `upstream_model` on the upstream request and restores the public name in supported responses.
 
 ## Configuration
 
@@ -40,11 +40,33 @@ Gemini upstream model names accept a single ASCII letter/digit/`-_.` segment, op
 
 Each model declares:
 
-- `provider`: an ID from `llm.providers`.
-- `upstream_model`: the model name sent upstream.
-- `workloads`: a nonempty, duplicate-free list containing `chat`, `embedding`, or both for OpenAI Chat Completions providers; Responses, Anthropic, and Gemini support only `chat`. Invalid combinations fail startup.
+- `backends`: a nonempty list of upstream backends. Each has a model-scoped, unique, nonblank `id`, a `provider` ID from `llm.providers`, an `upstream_model`, and an optional integer `weight` (default `100`).
+- `workloads`: a nonempty, duplicate-free list containing `chat`, `embedding`, or both when every backend uses OpenAI Chat Completions; Responses, Anthropic, and Gemini support only `chat`. Every backend, including disabled entries, must support the model's declared workloads. Invalid combinations fail startup.
 - `allow_anonymous`: optional, default `false`.
 - `subjects`: client credential IDs allowed to invoke a protected model; optional only for anonymous models.
+
+Backend weights range from `0` to `4294967295`. Zero disables selection; a model with no positive weight fails startup. Backend IDs are independent of provider/model names and unique within their public model. Changing an ID changes the effective configuration identity. Backend list order does not express priority and does not change the configuration fingerprint.
+
+Legacy models using top-level `provider` and `upstream_model` remain accepted. They normalize in memory to one backend with `id: default` and `weight: 100`; an equivalent explicit backend has the same fingerprint. Mixing the legacy fields with `backends`, incomplete legacy pairs, explicit null routing fields, or unknown fields is rejected. Config serialization emits the normalized `backends` form; source files are not rewritten.
+
+```yaml
+chat-default:
+  backends:
+    - id: primary
+      provider: example
+      upstream_model: example-chat-model
+      weight: 80
+    - id: secondary
+      provider: responses-example
+      upstream_model: example-responses-model
+      weight: 20
+  workloads: [chat]
+  subjects: [local-client]
+```
+
+Authentication, authorization, and shared admission apply once to the public model. Nyro then prepares each enabled backend locally with its own protocol codec, excludes backends that cannot represent the request, and randomly selects one eligible backend in proportion to its weight. The weights apply to the eligible subset; they are not per-batch traffic guarantees. Preparation sends no network requests. If none can represent the request, the response is `400` and no upstream is called. For example, without a token limit an Anthropic backend is ineligible while a compatible OpenAI backend can still be selected. Preparation cannot determine actual provider availability or whether its eventual response is convertible.
+
+Each invocation makes exactly one upstream attempt. An upstream error, malformed response, or broken stream never triggers another backend. Request logs include the selected backend ID alongside the public model. Priority, retry/failover, and health-based selection remain subsequent work. Local routing regressions: `cargo test -p nyro-llm --test routing_runtime`.
 
 For a protected model, `subjects` must be nonempty and every value must match an `id` in `security.api_keys`. A request without a supported header credential, or with an unknown credential, receives `401`; a known subject not granted that model receives `403`. For an anonymous model, a missing credential is accepted. If a credential is supplied, it must still authenticate, but any known credential may use the anonymous model.
 
@@ -83,7 +105,7 @@ curl http://127.0.0.1:19530/v1beta/models/gemini-default:generateContent \
   -d '{"contents":[{"role":"user","parts":[{"text":"Hello"}]}],"generationConfig":{"maxOutputTokens":256}}'
 ```
 
-An alias selects the configured upstream independently of the client protocol. Requests routed to Anthropic require an explicit token limit (`max_tokens`, or a representable equivalent); Nyro does not invent one. Native clients routed to an OpenAI stream request upstream usage automatically. OpenAI Chat Completions clients receive usage only when `stream_options.include_usage` is true.
+An alias selects the configured upstream independently of the client protocol. An Anthropic backend is eligible only with an explicit token limit (`max_tokens`, or a representable equivalent); Nyro does not invent one. Native clients routed to an OpenAI stream request upstream usage automatically. OpenAI Chat Completions clients receive usage only when `stream_options.include_usage` is true.
 
 This is an experimental text/function Chat subset. New native codecs reject image/audio/video, thinking/signature blocks, unrepresentable content ordering, multiple candidates, and unsupported vendor options or diagnostics. Examples include Anthropic caching/usage details and matched stop-sequence responses; Gemini safety settings, safety ratings, grounding/citations, prompt feedback and structured-output settings; and OpenAI response fingerprint/service-tier/logprob metadata when it cannot be represented by a native output. Supported fields in one protocol are not automatically representable in another: unsupported requests fail before dispatch; unsupported upstream responses fail with `502` or a terminated SSE stream. Native Embedding APIs and full SDK/vendor feature parity remain future work.
 
@@ -113,7 +135,7 @@ References: [OpenAI Responses migration](https://developers.openai.com/api/docs/
 - `GET /healthz` returns `200` while the HTTP process is serving.
 - `GET /readyz` returns `200` while the kernel host accepts new generation leases and `503` once it does not. This source-built proxy has no database readiness check.
 
-Each request makes one attempt against its configured upstream. It does not implement retries, failover, rate limits, quotas, a control plane, Admin API, WebUI, `nyro serve`, or `nyro tool`. It does not expand environment variables, accept the legacy standalone YAML format, watch or hot-reload the file, or fetch configuration remotely. Restart the process to apply edits.
+Each request makes one attempt against its selected upstream. It does not implement retries, failover, rate limits, quotas, a control plane, Admin API, WebUI, `nyro serve`, or `nyro tool`. It does not expand environment variables, accept the legacy standalone YAML format, watch or hot-reload the file, or fetch configuration remotely. Restart the process to apply edits.
 
 Contributors can exercise the root process, probes, authentication, Chat, Embedding, SSE, redaction, and graceful termination without a real provider:
 

--- a/docs/standalone/rust-proxy.yaml
+++ b/docs/standalone/rust-proxy.yaml
@@ -41,8 +41,15 @@ llm:
       workloads: [chat]
       subjects: [local-client]
     chat-default:
-      provider: example
-      upstream_model: example-chat-model
+      backends:
+        - id: primary
+          provider: example
+          upstream_model: example-chat-model
+          weight: 80
+        - id: secondary
+          provider: responses-example
+          upstream_model: example-responses-model
+          weight: 20
       workloads: [chat]
       allow_anonymous: false
       subjects: [local-client]

--- a/docs/standalone/rust-proxy_CN.md
+++ b/docs/standalone/rust-proxy_CN.md
@@ -23,7 +23,7 @@ curl http://127.0.0.1:19530/v1/chat/completions \
   -d '{"model":"chat-default","messages":[{"role":"user","content":"Hello"}]}'
 ```
 
-当前入口实现 OpenAI Chat/Embedding、无状态 Responses、Anthropic Messages 和 Gemini generateContent 的强类型子集。Chat 支持四种已支持 Chat API 格式之间的文本、函数调用／结果及 SSE 转换，不承诺完整兼容各厂商 API。未知或尚未支持的请求字段会返回 `400`，不会原样转发；尚未支持的上游响应语义会在流开始前返回 `502`，如果出现在首帧校验后的 SSE 中则终止该流。配置中的模型名是公开别名：Nyro 向上游发送 `upstream_model`，并在已支持的响应中恢复公开模型名。
+当前入口实现 OpenAI Chat/Embedding、无状态 Responses、Anthropic Messages 和 Gemini generateContent 的强类型子集。Chat 支持四种已支持 Chat API 格式之间的文本、函数调用／结果及 SSE 转换，不承诺完整兼容各厂商 API。未知或尚未支持的请求字段会返回 `400`，不会原样转发；尚未支持的上游响应语义会在流开始前返回 `502`，如果出现在首帧校验后的 SSE 中则终止该流。配置中的模型名是公开别名：Nyro 向上游发送所选 backend 的 `upstream_model`，并在已支持的响应中恢复公开模型名。
 
 ## 配置
 
@@ -40,11 +40,33 @@ Gemini 上游模型名只接受由 ASCII 字母、数字、`-_.` 构成的单段
 
 每个模型包含：
 
-- `provider`：`llm.providers` 中的 ID。
-- `upstream_model`：发送给上游的模型名。
-- `workloads`：非空且不能重复；OpenAI Chat Completions Provider 可包含 `chat`、`embedding` 或两者；Responses／Anthropic／Gemini 只支持 `chat`。无效组合会在启动时被拒绝。
+- `backends`：非空上游列表。每项包含模型范围内唯一且非空白的 `id`、`llm.providers` 中的 `provider` ID、`upstream_model`，以及可选整数 `weight`（默认 `100`）。
+- `workloads`：非空且不能重复；所有 backend 都使用 OpenAI Chat Completions 时可包含 `chat`、`embedding` 或两者；Responses／Anthropic／Gemini 只支持 `chat`。每个 backend（包括禁用项）都必须支持模型声明的 workload，无效组合会在启动时被拒绝。
 - `allow_anonymous`：可选，默认 `false`。
 - `subjects`：允许调用受保护模型的客户端凭据 ID；只有匿名模型可以省略。
+
+Backend 权重范围是 `0` 到 `4294967295`；`0` 表示不参与选择，模型的全部权重为零时启动失败。Backend ID 独立于 Provider 和上游模型名，在所属公开模型内唯一；更改 ID 会改变有效配置身份。列表顺序不表示优先级，也不会改变配置指纹。
+
+旧模型顶层的 `provider` 和 `upstream_model` 写法继续兼容，在内存中归一化为 `id: default`、`weight: 100` 的单个 backend，与显式声明的等价配置具有相同指纹。拒绝新旧写法混用、缺少任一旧字段、显式 null 路由字段及未知字段。配置序列化输出归一化后的 `backends` 形式，不会改写源文件。
+
+```yaml
+chat-default:
+  backends:
+    - id: primary
+      provider: example
+      upstream_model: example-chat-model
+      weight: 80
+    - id: secondary
+      provider: responses-example
+      upstream_model: example-responses-model
+      weight: 20
+  workloads: [chat]
+  subjects: [local-client]
+```
+
+认证、授权和共享准入针对公开模型执行一次。随后 Nyro 使用各 backend 对应的 codec 在本地准备请求，排除无法表达当前请求的项，并按剩余权重随机选择一个。权重作用于可用候选集合，不保证每一批请求都严格按比例分配。准备阶段不发送网络请求；没有可表达请求的 backend 时返回 `400`。例如请求未提供 token 上限时，Anthropic backend 不参与选择，而兼容的 OpenAI backend 仍可参与。准备阶段不能确定 Provider 的实际可用性，也不能保证其后续响应可转换。
+
+每次调用只向选定上游尝试一次。上游错误、响应格式错误或断流不会触发其他 backend。请求日志会同时记录公开模型与所选 backend ID。优先级、重试／故障转移及基于健康状态的选择属于后续工作。本地路由回归：`cargo test -p nyro-llm --test routing_runtime`。
 
 受保护模型的 `subjects` 不能为空，每一项都必须匹配 `security.api_keys` 中的 `id`。未提供支持的请求头凭据或凭据未知时返回 `401`；凭据已知但无权访问该模型时返回 `403`。匿名模型可以不带凭据访问；如果请求带了凭据，该凭据仍须有效，但任意已知凭据都可以访问匿名模型。
 
@@ -83,7 +105,7 @@ curl http://127.0.0.1:19530/v1beta/models/gemini-default:generateContent \
   -d '{"contents":[{"role":"user","parts":[{"text":"Hello"}]}],"generationConfig":{"maxOutputTokens":256}}'
 ```
 
-模型别名选择上游，与客户端协议独立。路由到 Anthropic 时，请求必须显式提供 token 上限（`max_tokens` 或能转换的等价字段），Nyro 不自行设置默认值。原生客户端使用 OpenAI 流式上游时会自动请求用量；OpenAI Chat Completions 客户端只有设置 `stream_options.include_usage: true` 才接收用量。
+模型别名选择上游，与客户端协议独立。Anthropic backend 只有在请求显式提供 token 上限时才参与选择（`max_tokens` 或能转换的等价字段），Nyro 不自行设置默认值。原生客户端使用 OpenAI 流式上游时会自动请求用量；OpenAI Chat Completions 客户端只有设置 `stream_options.include_usage: true` 才接收用量。
 
 这是实验性的文本／函数 Chat 子集。新原生 codec 拒绝图片、音频、视频、thinking／签名块、无法保留的内容顺序、多候选以及不支持的厂商选项或诊断字段。例如 Anthropic 缓存／用量扩展和命中 stop sequence 的响应；Gemini 安全设置、safety ratings、grounding／引用、prompt feedback 和结构化输出设置；以及无法在原生输出中表示的 OpenAI fingerprint／service-tier／logprob 元数据。某协议已支持的字段不一定能转换到另一协议：不可转换的请求在发往上游前失败；不可转换的上游响应返回 `502` 或终止 SSE 流。原生 Embedding API 和完整 SDK／厂商功能对齐属于后续工作。
 
@@ -113,7 +135,7 @@ SSE 使用 Responses 命名生命周期事件、稳定 item ID、递增序号和
 - HTTP 服务运行期间，`GET /healthz` 返回 `200`。
 - 内核 Host 接受新的代际 lease 时，`GET /readyz` 返回 `200`；停止接受时返回 `503`。这个源码构建代理没有数据库就绪检查。
 
-当前每个请求只向配置的上游尝试一次。尚未实现重试、故障转移、频率限制、额度、控制面、Admin API、WebUI、`nyro serve` 或 `nyro tool`。程序不会展开环境变量，不接受旧 Standalone YAML，不监听或热更新文件，也不会远程获取配置；修改后需要重启进程。
+当前每个请求只向选定上游尝试一次。尚未实现重试、故障转移、频率限制、额度、控制面、Admin API、WebUI、`nyro serve` 或 `nyro tool`。程序不会展开环境变量，不接受旧 Standalone YAML，不监听或热更新文件，也不会远程获取配置；修改后需要重启进程。
 
 贡献者可以在不连接真实 Provider 的情况下验证根进程、健康检查、认证、Chat、Embedding、SSE、脱敏和正常退出：
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -129,7 +129,7 @@ limit: {{concurrency: 1}}
         assert_eq!(old.status(), StatusCode::OK);
         assert_eq!(host.status().active.unwrap().leases, 1);
         let mut next = config.clone();
-        next.llm.models.get_mut("public").unwrap().upstream_model = "new-model".into();
+        next.llm.models.get_mut("public").unwrap().backends[0].upstream_model = "new-model".into();
         host.activate(
             resources.candidate(&next).unwrap(),
             Context {

--- a/tests/proxy_smoke.py
+++ b/tests/proxy_smoke.py
@@ -74,6 +74,11 @@ def main():
                 "models": {"public": {"provider": "mock", "upstream_model": "internal",
                                       "workloads": ["chat", "embedding"], "subjects": ["tester"]}}},
                 "security": {"api_keys": [{"id": "tester", "secret": "client-secret"}]}}
+            data["llm"]["models"]["public-routed"] = {
+                "backends": [
+                    {"id": "disabled", "provider": "mock", "upstream_model": "must-not-run", "weight": 0},
+                    {"id": "enabled", "provider": "mock", "upstream_model": "internal"}],
+                "workloads": ["chat"], "subjects": ["tester"]}
             config.write_text(json.dumps({**data, "unknown": "secret-marker"}))
             invalid = subprocess.run([binary, "proxy", "--config", config], capture_output=True, timeout=5)
             assert invalid.returncode != 0
@@ -126,7 +131,13 @@ def main():
                         result = json.loads(body)
                         assert result["status"] == "completed"
                         assert result["output"][0]["content"][0]["text"] == "Hello"
-                assert len(Upstream.calls) == 9
+                for streaming in (False, True):
+                    status, body = request("/v1/chat/completions", {
+                        **chat, "model": "public-routed", "stream": streaming})
+                    assert status == 200 and b"public-routed" in body
+                    if streaming:
+                        assert body.endswith(b"data: [DONE]\n\n")
+                assert len(Upstream.calls) == 11
                 assert all(key == "Bearer upstream-secret" and payload["model"] == "internal"
                            for _, key, payload in Upstream.calls)
                 process.terminate()
@@ -141,7 +152,7 @@ def main():
     finally:
         upstream.shutdown()
         upstream.server_close()
-    print("proxy smoke passed: config, probes, auth, OpenAI/Anthropic/Gemini Chat/Responses, Embedding, SSE, SIGTERM")
+    print("proxy smoke passed: config, weighted routing, probes, auth, OpenAI/Anthropic/Gemini Chat/Responses, Embedding, SSE, SIGTERM")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
BREAKING CHANGE: Rust Model constructors use backends instead of provider and upstream_model. Existing single-backend YAML remains supported.