### PR TITLE
feat(limit): add cumulative model token quotas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Nyro is a Rust workspace for a local AI protocol gateway with a Tauri desktop ap
 | `crates/nyro-llm/` | New typed LLM runtime, OpenAI/Anthropic/Gemini Chat codecs/providers, and request execution. |
 | `crates/nyro-config/` | Strict standalone file configuration for the experimental root proxy. |
 | `crates/nyro-security/` | Transport-neutral credential authentication and authorization primitives. |
-| `crates/nyro-limit/` | Shared concurrency and token-bucket rate admission primitives. |
+| `crates/nyro-limit/` | Shared concurrency, token-bucket rate admission, and cumulative quota primitives. |
 | `crates/nyro-core/` | Core Rust library: gateway, proxy, protocol conversion, provider adapters, storage, admin service. |
 | `crates/nyro-tools/` | Rust CLI/tooling crate. |
 | `src-server/` | Standalone server binary exposing proxy/admin HTTP surfaces. |

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Claude Code · Codex CLI · Gemini CLI · OpenCode
 
 Nyro ships as a **desktop app** (macOS / Windows / Linux) and a **standalone server binary** for headless and self-hosted deployments.
 
-An experimental new Rust `nyro proxy` data plane is also available for source builds. It has its own strict file format and currently supports OpenAI Chat/Embedding, stateless Responses, and Anthropic/Gemini Chat subsets, with priority and weighted backend selection, opt-in bounded failover, passive health, and per-model request rate limits; see the [Rust file-config proxy guide](docs/standalone/rust-proxy.md). Released `nyro-server` commands and configuration remain unchanged.
+An experimental new Rust `nyro proxy` data plane is also available for source builds. It has its own strict file format and currently supports OpenAI Chat/Embedding, stateless Responses, and Anthropic/Gemini Chat subsets, with priority and weighted backend selection, opt-in bounded failover, passive health, per-model request rate limits, and cumulative token quotas; see the [Rust file-config proxy guide](docs/standalone/rust-proxy.md). Released `nyro-server` commands and configuration remain unchanged.
 
 ---
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -43,7 +43,7 @@ Claude Code · Codex CLI · Gemini CLI · OpenCode
 
 Nyro 同时提供 **桌面应用**（macOS / Windows / Linux）和 **独立服务端二进制**，适用于无头部署与自托管场景。
 
-源码中另有实验性的新 Rust `nyro proxy` 数据面，使用独立的严格文件格式，目前支持 OpenAI Chat/Embedding、无状态 Responses 及 Anthropic/Gemini Chat 子集，并支持 backend 优先级与加权选择、可选的有界故障转移、被动健康检查和按模型共享的请求频率限制；详见 [Rust 文件配置代理指南](docs/standalone/rust-proxy_CN.md)。已发布 `nyro-server` 的命令和配置保持不变。
+源码中另有实验性的新 Rust `nyro proxy` 数据面，使用独立的严格文件格式，目前支持 OpenAI Chat/Embedding、无状态 Responses 及 Anthropic/Gemini Chat 子集，并支持 backend 优先级与加权选择、可选的有界故障转移、被动健康检查、按模型共享的请求频率限制与累计 token 额度；详见 [Rust 文件配置代理指南](docs/standalone/rust-proxy_CN.md)。已发布 `nyro-server` 的命令和配置保持不变。
 
 ---
 

--- a/crates/nyro-config/tests/config.rs
+++ b/crates/nyro-config/tests/config.rs
@@ -29,6 +29,7 @@ fn valid_config() -> Config {
                     max_attempts: 1,
                     health: None,
                     rate: None,
+                    quota: None,
                     backends: vec![Backend {
                         id: "default".into(),
                         provider: "openai".into(),
@@ -494,6 +495,64 @@ fn yaml_rejects_invalid_rate_policy_values() {
         assert!(
             Config::from_yaml(&yaml_with_routing(&format!(
                 "      provider: p\n      upstream_model: u\n      rate: {policy}"
+            )))
+            .is_err(),
+            "{policy}"
+        );
+    }
+}
+
+#[test]
+fn quota_fingerprint_retains_both_policy_fields_and_omission_disables_it() {
+    let parse = |quota: &str| {
+        Config::from_yaml(&yaml_with_routing(&format!(
+            "      provider: p\n      upstream_model: u\n{quota}"
+        )))
+        .unwrap()
+    };
+    let disabled = parse("");
+    let enabled = parse("      quota: {total_tokens: 100, reserve_tokens: 20}");
+    assert_ne!(
+        disabled.fingerprint().unwrap(),
+        enabled.fingerprint().unwrap()
+    );
+    let reordered = parse("      quota: {reserve_tokens: 20, total_tokens: 100}");
+    assert_eq!(
+        enabled.fingerprint().unwrap(),
+        reordered.fingerprint().unwrap()
+    );
+    for changed in [
+        "      quota: {total_tokens: 101, reserve_tokens: 20}",
+        "      quota: {total_tokens: 100, reserve_tokens: 21}",
+    ] {
+        assert_ne!(
+            enabled.fingerprint().unwrap(),
+            parse(changed).fingerprint().unwrap()
+        );
+    }
+}
+
+#[test]
+fn yaml_rejects_invalid_quota_policy_values() {
+    for policy in [
+        "null",
+        "{}",
+        "{total_tokens: 100}",
+        "{reserve_tokens: 20}",
+        "{total_tokens: 0, reserve_tokens: 20}",
+        "{total_tokens: 100, reserve_tokens: 0}",
+        "{total_tokens: 10, reserve_tokens: 20}",
+        "{total_tokens: -1, reserve_tokens: 20}",
+        "{total_tokens: 100, reserve_tokens: -1}",
+        "{total_tokens: null, reserve_tokens: 20}",
+        "{total_tokens: 100, reserve_tokens: null}",
+        "{total_tokens: 18446744073709551616, reserve_tokens: 20}",
+        "{total_tokens: 100, reserve_tokens: 18446744073709551616}",
+        "{total_tokens: 100, reserve_tokens: 20, unknown: true}",
+    ] {
+        assert!(
+            Config::from_yaml(&yaml_with_routing(&format!(
+                "      provider: p\n      upstream_model: u\n      quota: {policy}"
             )))
             .is_err(),
             "{policy}"

--- a/crates/nyro-limit/src/lib.rs
+++ b/crates/nyro-limit/src/lib.rs
@@ -1,5 +1,6 @@
 //! nyro-limit.
 
+pub mod quota;
 pub mod rate;
 
 use std::sync::Arc;

--- a/crates/nyro-limit/src/quota.rs
+++ b/crates/nyro-limit/src/quota.rs
@@ -1,0 +1,304 @@
+//! Process-local cumulative admission for arbitrary units.
+
+use std::sync::{Arc, Mutex};
+use thiserror::Error;
+
+/// A cumulative budget with no refill or reset. Clones share one balance.
+#[derive(Clone, Debug)]
+pub struct Quota {
+    state: Arc<Mutex<QuotaSnapshot>>,
+}
+
+#[derive(Clone, Copy, Debug, Error, Eq, PartialEq)]
+pub enum QuotaError {
+    #[error("quota limit and reservation amount must be positive")]
+    Invalid,
+    #[error("quota limit exceeded")]
+    Exceeded,
+}
+
+/// An atomic view of settled usage and pending reservations.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct QuotaSnapshot {
+    pub limit: u64,
+    /// Actual settled usage, including any overage beyond the limit.
+    pub used: u128,
+    pub reserved: u64,
+}
+
+/// A pending charge. Dropping it charges its reserved amount exactly once.
+#[must_use = "a dropped reservation charges its reserved amount"]
+#[derive(Debug)]
+pub struct Reservation {
+    quota: Quota,
+    amount: u64,
+}
+
+impl Quota {
+    pub fn new(limit: u64) -> Result<Self, QuotaError> {
+        if limit == 0 {
+            return Err(QuotaError::Invalid);
+        }
+        Ok(Self {
+            state: Arc::new(Mutex::new(QuotaSnapshot {
+                limit,
+                used: 0,
+                reserved: 0,
+            })),
+        })
+    }
+
+    /// Reserve positive units if settled usage plus pending units leaves room.
+    pub fn reserve(&self, amount: u64) -> Result<Reservation, QuotaError> {
+        if amount == 0 {
+            return Err(QuotaError::Invalid);
+        }
+        let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
+        if state.used + u128::from(state.reserved) + u128::from(amount) > u128::from(state.limit) {
+            return Err(QuotaError::Exceeded);
+        }
+        // Admission above guarantees reserved + amount fits the u64 limit.
+        state.reserved += amount;
+        Ok(Reservation {
+            quota: self.clone(),
+            amount,
+        })
+    }
+
+    pub fn snapshot(&self) -> QuotaSnapshot {
+        *self.state.lock().unwrap_or_else(|error| error.into_inner())
+    }
+}
+
+impl Reservation {
+    pub fn amount(&self) -> u64 {
+        self.amount
+    }
+
+    /// Replace this reservation with actual usage, retaining any overage debt.
+    pub fn settle(mut self, actual: u64) {
+        self.finish(actual);
+    }
+
+    /// Explicitly settle zero usage and return all reserved capacity.
+    pub fn release(self) {
+        self.settle(0);
+    }
+
+    fn finish(&mut self, actual: u64) {
+        if self.amount == 0 {
+            return;
+        }
+        let mut state = self
+            .quota
+            .state
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        state.reserved -= self.amount;
+        // Once used reaches limit, admission stops. At most limit positive
+        // reservations can still settle u64 amounts, so u128 cannot overflow.
+        state.used += u128::from(actual);
+        self.amount = 0;
+    }
+}
+
+impl Drop for Reservation {
+    fn drop(&mut self) {
+        self.finish(self.amount);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{sync::Barrier, thread};
+
+    #[test]
+    fn rejects_zero_limits_and_reservations_without_mutation() {
+        assert_eq!(Quota::new(0).unwrap_err(), QuotaError::Invalid);
+        let quota = Quota::new(10).unwrap();
+        assert_eq!(quota.reserve(0).unwrap_err(), QuotaError::Invalid);
+        assert_eq!(
+            quota.snapshot(),
+            QuotaSnapshot {
+                limit: 10,
+                used: 0,
+                reserved: 0
+            }
+        );
+    }
+
+    #[test]
+    fn clones_share_used_and_pending_capacity_at_exact_boundary() {
+        let quota = Quota::new(10).unwrap();
+        let clone = quota.clone();
+        quota.reserve(4).unwrap().settle(3);
+        let pending = clone.reserve(7).unwrap();
+        assert_eq!(pending.amount(), 7);
+        assert_eq!(
+            quota.snapshot(),
+            QuotaSnapshot {
+                limit: 10,
+                used: 3,
+                reserved: 7
+            }
+        );
+        assert_eq!(quota.reserve(1).unwrap_err(), QuotaError::Exceeded);
+        assert_eq!(clone.snapshot(), quota.snapshot());
+        pending.settle(7);
+        assert_eq!(
+            quota.snapshot(),
+            QuotaSnapshot {
+                limit: 10,
+                used: 10,
+                reserved: 0
+            }
+        );
+    }
+
+    #[test]
+    fn lower_actual_refunds_unused_reservation_exactly_once() {
+        let quota = Quota::new(10).unwrap();
+        quota.reserve(10).unwrap().settle(4);
+        assert_eq!(
+            quota.snapshot(),
+            QuotaSnapshot {
+                limit: 10,
+                used: 4,
+                reserved: 0
+            }
+        );
+        let pending = quota.reserve(6).unwrap();
+        assert_eq!(quota.reserve(1).unwrap_err(), QuotaError::Exceeded);
+        pending.settle(0);
+        assert_eq!(
+            quota.snapshot(),
+            QuotaSnapshot {
+                limit: 10,
+                used: 4,
+                reserved: 0
+            }
+        );
+    }
+
+    #[test]
+    fn release_restores_capacity_without_drop_charge() {
+        let quota = Quota::new(10).unwrap();
+        quota.reserve(10).unwrap().release();
+        assert_eq!(
+            quota.snapshot(),
+            QuotaSnapshot {
+                limit: 10,
+                used: 0,
+                reserved: 0
+            }
+        );
+        assert_eq!(quota.reserve(10).unwrap().amount(), 10);
+    }
+
+    #[test]
+    fn abandoned_reservations_charge_their_amount() {
+        let quota = Quota::new(10).unwrap();
+        drop(quota.reserve(6).unwrap());
+        assert_eq!(
+            quota.snapshot(),
+            QuotaSnapshot {
+                limit: 10,
+                used: 6,
+                reserved: 0
+            }
+        );
+        assert_eq!(quota.reserve(5).unwrap_err(), QuotaError::Exceeded);
+        drop(quota.reserve(4).unwrap());
+        assert_eq!(quota.snapshot().used, 10);
+    }
+
+    #[test]
+    fn overage_records_debt_and_preserves_other_pending_reservations() {
+        let quota = Quota::new(10).unwrap();
+        let first = quota.reserve(4).unwrap();
+        let second = quota.reserve(6).unwrap();
+        first.settle(20);
+        assert_eq!(
+            quota.snapshot(),
+            QuotaSnapshot {
+                limit: 10,
+                used: 20,
+                reserved: 6
+            }
+        );
+        assert_eq!(quota.reserve(1).unwrap_err(), QuotaError::Exceeded);
+        second.release();
+        assert_eq!(
+            quota.snapshot(),
+            QuotaSnapshot {
+                limit: 10,
+                used: 20,
+                reserved: 0
+            }
+        );
+        assert_eq!(quota.reserve(1).unwrap_err(), QuotaError::Exceeded);
+    }
+
+    #[test]
+    fn maximum_amounts_do_not_wrap_admission_or_cumulative_debt() {
+        let quota = Quota::new(u64::MAX).unwrap();
+        let first = quota.reserve(u64::MAX - 1).unwrap();
+        assert_eq!(quota.reserve(2).unwrap_err(), QuotaError::Exceeded);
+        let second = quota.reserve(1).unwrap();
+        assert_eq!(quota.reserve(u64::MAX).unwrap_err(), QuotaError::Exceeded);
+        first.settle(u64::MAX);
+        second.settle(u64::MAX);
+        assert_eq!(
+            quota.snapshot(),
+            QuotaSnapshot {
+                limit: u64::MAX,
+                used: u128::from(u64::MAX) * 2,
+                reserved: 0,
+            }
+        );
+        assert_eq!(quota.reserve(u64::MAX).unwrap_err(), QuotaError::Exceeded);
+    }
+
+    #[test]
+    fn concurrent_reservations_and_settlements_share_one_atomic_balance() {
+        let quota = Quota::new(30).unwrap();
+        let start = Barrier::new(16);
+        let settle = Barrier::new(16);
+        thread::scope(|scope| {
+            let workers: Vec<_> = (0..16)
+                .map(|_| {
+                    let quota = quota.clone();
+                    let start = &start;
+                    let settle = &settle;
+                    scope.spawn(move || {
+                        start.wait();
+                        let pending = quota.reserve(10).ok();
+                        settle.wait();
+                        if let Some(pending) = pending {
+                            pending.settle(7);
+                            true
+                        } else {
+                            false
+                        }
+                    })
+                })
+                .collect();
+            let admitted = workers
+                .into_iter()
+                .map(|worker| usize::from(worker.join().unwrap()))
+                .sum::<usize>();
+            assert_eq!(admitted, 3);
+        });
+        assert_eq!(
+            quota.snapshot(),
+            QuotaSnapshot {
+                limit: 30,
+                used: 21,
+                reserved: 0
+            }
+        );
+        assert_eq!(quota.reserve(10).unwrap_err(), QuotaError::Exceeded);
+        quota.reserve(9).unwrap().release();
+    }
+}

--- a/crates/nyro-llm/src/config.rs
+++ b/crates/nyro-llm/src/config.rs
@@ -62,6 +62,8 @@ pub struct Model {
     pub health: Option<HealthConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rate: Option<RateConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quota: Option<QuotaConfig>,
     pub workloads: Vec<Workload>,
     pub allow_anonymous: bool,
     pub subjects: BTreeSet<String>,
@@ -105,6 +107,14 @@ pub struct RateConfig {
     pub burst: u32,
 }
 
+/// Process-local cumulative token budget and provision reserved per upstream attempt.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct QuotaConfig {
+    pub total_tokens: u64,
+    pub reserve_tokens: u64,
+}
+
 const fn default_burst() -> u32 {
     1
 }
@@ -126,6 +136,8 @@ struct RawModel {
     health: Option<HealthConfig>,
     #[serde(default, deserialize_with = "present")]
     rate: Option<RateConfig>,
+    #[serde(default, deserialize_with = "present")]
+    quota: Option<QuotaConfig>,
     #[serde(default, deserialize_with = "present")]
     backends: Option<Vec<Backend>>,
     #[serde(default, deserialize_with = "present")]
@@ -171,6 +183,7 @@ impl<'de> Deserialize<'de> for Model {
             max_attempts: raw.max_attempts,
             health: raw.health,
             rate: raw.rate,
+            quota: raw.quota,
             workloads: raw.workloads,
             allow_anonymous: raw.allow_anonymous,
             subjects: raw.subjects,
@@ -200,6 +213,10 @@ pub enum ConfigError {
     InvalidHealth { model: String },
     #[error("model `{model}` rate policy requires positive, representable bounds")]
     InvalidRate { model: String },
+    #[error(
+        "model `{model}` quota policy requires positive bounds and reserve_tokens <= total_tokens"
+    )]
+    InvalidQuota { model: String },
     #[error("model `{model}` must define at least one backend")]
     NoBackends { model: String },
     #[error("model `{model}` has an empty backend ID")]
@@ -294,6 +311,13 @@ impl Config {
                 .is_err()
             }) {
                 return Err(ConfigError::InvalidRate { model: id.clone() });
+            }
+            if model.quota.as_ref().is_some_and(|quota| {
+                quota.total_tokens == 0
+                    || quota.reserve_tokens == 0
+                    || quota.reserve_tokens > quota.total_tokens
+            }) {
+                return Err(ConfigError::InvalidQuota { model: id.clone() });
             }
             if model.backends.is_empty() {
                 return Err(ConfigError::NoBackends { model: id.clone() });

--- a/crates/nyro-llm/src/lib.rs
+++ b/crates/nyro-llm/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod health;
 mod ingress;
 mod provider;
+pub mod quota;
 pub mod rate;
 mod router;
 pub mod runtime;

--- a/crates/nyro-llm/src/quota.rs
+++ b/crates/nyro-llm/src/quota.rs
@@ -1,0 +1,371 @@
+//! Cumulative model token accounting shared across runtime generations.
+
+use crate::{EmbeddingUsage, Usage, codec::CodecError, config::QuotaConfig, runtime::BuildError};
+use nyro_limit::quota::{Quota, QuotaError, QuotaSnapshot, Reservation};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+/// Retains consumed and pending balances even after a model is removed.
+/// A live or consumed policy can only be changed by replacing the registry.
+#[derive(Default)]
+pub struct QuotaRegistry {
+    entries: Mutex<HashMap<String, Arc<BoundQuota>>>,
+}
+
+impl QuotaRegistry {
+    pub fn snapshot(&self, model: &str) -> Option<QuotaSnapshot> {
+        self.entries
+            .lock()
+            .unwrap()
+            .get(model)
+            .map(|bound| bound.quota.snapshot())
+    }
+
+    pub(crate) fn bind(
+        &self,
+        model: &str,
+        policy: &QuotaConfig,
+    ) -> Result<Arc<BoundQuota>, BuildError> {
+        if policy.total_tokens == 0
+            || policy.reserve_tokens == 0
+            || policy.reserve_tokens > policy.total_tokens
+        {
+            return Err(BuildError);
+        }
+        let mut entries = self.entries.lock().unwrap();
+        entries.retain(|_, bound| {
+            let balance = bound.quota.snapshot();
+            Arc::strong_count(bound) > 1 || balance.used > 0 || balance.reserved > 0
+        });
+        if let Some(bound) = entries.get(model) {
+            return if bound.policy == *policy {
+                Ok(Arc::clone(bound))
+            } else {
+                Err(BuildError)
+            };
+        }
+        let bound = Arc::new(BoundQuota {
+            model: model.into(),
+            policy: policy.clone(),
+            quota: Quota::new(policy.total_tokens).map_err(|_| BuildError)?,
+        });
+        entries.insert(model.into(), Arc::clone(&bound));
+        Ok(bound)
+    }
+}
+
+pub(crate) struct BoundQuota {
+    model: String,
+    policy: QuotaConfig,
+    quota: Quota,
+}
+impl BoundQuota {
+    pub(crate) fn reserve(&self, backend: &str) -> Result<AttemptQuota, QuotaError> {
+        Ok(AttemptQuota {
+            reservation: Some(self.quota.reserve(self.policy.reserve_tokens)?),
+            model: self.model.clone(),
+            backend: backend.into(),
+            observed: None,
+        })
+    }
+}
+
+pub(crate) struct AttemptQuota {
+    reservation: Option<Reservation>,
+    model: String,
+    backend: String,
+    observed: Option<u64>,
+}
+impl AttemptQuota {
+    pub(crate) fn observe(&mut self, usage: &Usage) -> Result<(), CodecError> {
+        if usage.prompt_tokens.checked_add(usage.completion_tokens) != Some(usage.total_tokens) {
+            return Err(CodecError("invalid token usage total".into()));
+        }
+        self.observe_total(usage.total_tokens)
+    }
+
+    pub(crate) fn observe_embedding(&mut self, usage: &EmbeddingUsage) -> Result<(), CodecError> {
+        if usage.prompt_tokens != usage.total_tokens {
+            return Err(CodecError("invalid embedding token usage total".into()));
+        }
+        self.observe_total(usage.total_tokens)
+    }
+
+    fn observe_total(&mut self, total: u64) -> Result<(), CodecError> {
+        if self.observed.is_some_and(|previous| total < previous) {
+            return Err(CodecError("decreasing cumulative token usage".into()));
+        }
+        self.observed = Some(total);
+        Ok(())
+    }
+
+    pub(crate) fn complete(mut self) {
+        let actual = self.observed.unwrap_or_else(|| self.fallback());
+        self.settle(actual, "complete");
+    }
+
+    pub(crate) fn release(mut self) {
+        self.settle(0, "released");
+    }
+
+    fn fallback(&self) -> u64 {
+        self.reservation
+            .as_ref()
+            .map_or(0, Reservation::amount)
+            .max(self.observed.unwrap_or(0))
+    }
+
+    fn settle(&mut self, charged_units: u64, outcome: &'static str) {
+        if let Some(reservation) = self.reservation.take() {
+            reservation.settle(charged_units);
+            tracing::debug!(
+                model = %self.model,
+                backend = %self.backend,
+                charged_units,
+                known_usage = self.observed.is_some(),
+                outcome,
+                "upstream attempt quota settled"
+            );
+        }
+    }
+}
+
+impl Drop for AttemptQuota {
+    fn drop(&mut self) {
+        self.settle(self.fallback(), "fallback");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn policy() -> QuotaConfig {
+        QuotaConfig {
+            total_tokens: 100,
+            reserve_tokens: 20,
+        }
+    }
+
+    fn usage(prompt_tokens: u64, completion_tokens: u64, total_tokens: u64) -> Usage {
+        Usage {
+            prompt_tokens,
+            completion_tokens,
+            total_tokens,
+            prompt_tokens_details: None,
+            completion_tokens_details: None,
+        }
+    }
+
+    #[test]
+    fn completed_actual_refunds_reservation_including_explicit_zero() {
+        let registry = QuotaRegistry::default();
+        let bound = registry.bind("chat", &policy()).unwrap();
+        for (actual, expected) in [(8, 8), (0, 8), (30, 38)] {
+            let mut attempt = bound.reserve("primary").unwrap();
+            assert_eq!(registry.snapshot("chat").unwrap().reserved, 20);
+            attempt.observe(&usage(actual, 0, actual)).unwrap();
+            attempt.complete();
+            assert_eq!(
+                registry.snapshot("chat").unwrap(),
+                QuotaSnapshot {
+                    limit: 100,
+                    used: expected,
+                    reserved: 0
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn missing_usage_and_abandoned_partial_usage_charge_conservative_fallback() {
+        let registry = QuotaRegistry::default();
+        let bound = registry.bind("chat", &policy()).unwrap();
+        bound.reserve("primary").unwrap().complete();
+        assert_eq!(registry.snapshot("chat").unwrap().used, 20);
+        let mut partial = bound.reserve("primary").unwrap();
+        partial.observe(&usage(3, 2, 5)).unwrap();
+        drop(partial);
+        assert_eq!(registry.snapshot("chat").unwrap().used, 40);
+        let mut overage = bound.reserve("fallback").unwrap();
+        overage.observe(&usage(10, 70, 80)).unwrap();
+        drop(overage);
+        assert_eq!(
+            registry.snapshot("chat").unwrap(),
+            QuotaSnapshot {
+                limit: 100,
+                used: 120,
+                reserved: 0
+            }
+        );
+        assert!(matches!(
+            bound.reserve("primary"),
+            Err(QuotaError::Exceeded)
+        ));
+    }
+
+    #[test]
+    fn known_connect_failure_releases_all_reserved_credit() {
+        let registry = QuotaRegistry::default();
+        let bound = registry.bind("chat", &policy()).unwrap();
+        bound.reserve("primary").unwrap().release();
+        assert_eq!(registry.snapshot("chat").unwrap().used, 0);
+        assert_eq!(registry.snapshot("chat").unwrap().reserved, 0);
+    }
+
+    #[test]
+    fn cumulative_snapshots_replace_prior_totals_and_reject_invalid_updates() {
+        let registry = QuotaRegistry::default();
+        let bound = registry.bind("chat", &policy()).unwrap();
+        let mut attempt = bound.reserve("primary").unwrap();
+        for snapshot in [usage(3, 2, 5), usage(3, 2, 5), usage(3, 7, 10)] {
+            attempt.observe(&snapshot).unwrap();
+        }
+        for invalid in [usage(3, 6, 9), usage(10, 10, 100), usage(u64::MAX, 1, 0)] {
+            assert!(attempt.observe(&invalid).is_err());
+        }
+        attempt.complete();
+        assert_eq!(registry.snapshot("chat").unwrap().used, 10);
+    }
+
+    #[test]
+    fn invalid_first_usage_does_not_turn_unknown_outcome_into_free_usage() {
+        let registry = QuotaRegistry::default();
+        let bound = registry.bind("chat", &policy()).unwrap();
+        let mut attempt = bound.reserve("primary").unwrap();
+        assert!(attempt.observe(&usage(1, 1, 0)).is_err());
+        drop(attempt);
+        assert_eq!(registry.snapshot("chat").unwrap().used, 20);
+    }
+
+    #[test]
+    fn embeddings_validate_prompt_total_and_settle_actual() {
+        let registry = QuotaRegistry::default();
+        let bound = registry.bind("embedding", &policy()).unwrap();
+        let mut attempt = bound.reserve("primary").unwrap();
+        assert!(
+            attempt
+                .observe_embedding(&EmbeddingUsage {
+                    prompt_tokens: 7,
+                    total_tokens: 0
+                })
+                .is_err()
+        );
+        attempt
+            .observe_embedding(&EmbeddingUsage {
+                prompt_tokens: 7,
+                total_tokens: 7,
+            })
+            .unwrap();
+        attempt.complete();
+        assert_eq!(registry.snapshot("embedding").unwrap().used, 7);
+    }
+
+    #[test]
+    fn consumed_ledger_survives_removal_and_failed_candidate_drop() {
+        let registry = QuotaRegistry::default();
+        let original = registry.bind("chat", &policy()).unwrap();
+        drop(original.reserve("primary").unwrap());
+        let candidate = registry.bind("chat", &policy()).unwrap();
+        assert!(Arc::ptr_eq(&original, &candidate));
+        drop(candidate);
+        drop(original);
+        let other = registry.bind("alias", &policy()).unwrap();
+        assert_eq!(registry.snapshot("chat").unwrap().used, 20);
+        let readded = registry.bind("chat", &policy()).unwrap();
+        drop(readded.reserve("new-backend").unwrap());
+        assert_eq!(registry.snapshot("chat").unwrap().used, 40);
+        assert_eq!(registry.snapshot("alias").unwrap().used, 0);
+        drop(other);
+    }
+
+    #[test]
+    fn pending_attempt_retains_ledger_without_runtime_owner() {
+        let registry = QuotaRegistry::default();
+        let original = registry.bind("chat", &policy()).unwrap();
+        let attempt = original.reserve("primary").unwrap();
+        drop(original);
+        let changed = QuotaConfig {
+            total_tokens: 200,
+            ..policy()
+        };
+        assert!(registry.bind("chat", &changed).is_err());
+        assert_eq!(registry.snapshot("chat").unwrap().reserved, 20);
+        drop(attempt);
+        assert_eq!(registry.snapshot("chat").unwrap().used, 20);
+        assert!(registry.bind("chat", &changed).is_err());
+    }
+
+    #[test]
+    fn policy_changes_reject_live_or_consumed_bindings_without_resetting_them() {
+        let registry = QuotaRegistry::default();
+        let live = registry.bind("chat", &policy()).unwrap();
+        for changed in [
+            QuotaConfig {
+                total_tokens: 200,
+                ..policy()
+            },
+            QuotaConfig {
+                reserve_tokens: 30,
+                ..policy()
+            },
+        ] {
+            assert!(registry.bind("chat", &changed).is_err());
+        }
+        drop(live.reserve("primary").unwrap());
+        drop(live);
+        assert!(
+            registry
+                .bind(
+                    "chat",
+                    &QuotaConfig {
+                        total_tokens: 200,
+                        ..policy()
+                    }
+                )
+                .is_err()
+        );
+        assert_eq!(registry.snapshot("chat").unwrap().used, 20);
+    }
+
+    #[test]
+    fn unused_failed_candidates_are_pruned_and_do_not_pin_policy() {
+        let registry = QuotaRegistry::default();
+        let candidate = registry.bind("unused", &policy()).unwrap();
+        drop(candidate);
+        let changed = QuotaConfig {
+            total_tokens: 200,
+            ..policy()
+        };
+        let live = registry.bind("chat", &changed).unwrap();
+        assert!(registry.snapshot("unused").is_none());
+        let replacement = registry.bind("unused", &changed).unwrap();
+        assert_eq!(registry.snapshot("unused").unwrap().limit, 200);
+        drop(replacement);
+        drop(live);
+    }
+
+    #[test]
+    fn invalid_policies_do_not_create_ledgers() {
+        let registry = QuotaRegistry::default();
+        for invalid in [
+            QuotaConfig {
+                total_tokens: 0,
+                ..policy()
+            },
+            QuotaConfig {
+                reserve_tokens: 0,
+                ..policy()
+            },
+            QuotaConfig {
+                reserve_tokens: 101,
+                ..policy()
+            },
+        ] {
+            assert!(registry.bind("chat", &invalid).is_err());
+            assert!(registry.snapshot("chat").is_none());
+        }
+    }
+}

--- a/crates/nyro-llm/src/runtime.rs
+++ b/crates/nyro-llm/src/runtime.rs
@@ -20,6 +20,7 @@ use crate::{
     health::{BackendHealth, HealthRegistry},
     ingress::body::{self, Outcome},
     provider::Driver,
+    quota::{BoundQuota, QuotaRegistry},
     rate::{BoundRate, RateRegistry},
     router,
 };
@@ -27,6 +28,14 @@ use crate::{
 mod endpoint;
 mod response;
 mod stream;
+
+/// Application-owned state shared by immutable runtime generations.
+#[derive(Clone, Default)]
+pub struct SharedResources {
+    pub health: Arc<HealthRegistry>,
+    pub rates: Arc<RateRegistry>,
+    pub quotas: Arc<QuotaRegistry>,
+}
 
 #[derive(Clone, Copy, Debug)]
 pub struct Options {
@@ -60,6 +69,7 @@ pub struct Runtime {
     options: Options,
     health: BTreeMap<String, BTreeMap<String, Arc<BackendHealth>>>,
     rates: BTreeMap<String, Arc<BoundRate>>,
+    quotas: BTreeMap<String, Arc<BoundQuota>>,
 }
 
 impl Runtime {
@@ -69,13 +79,7 @@ impl Runtime {
         limit: ConcurrencyLimit,
         options: Options,
     ) -> Result<Self, BuildError> {
-        Self::with_health(
-            config,
-            keys,
-            limit,
-            options,
-            Arc::new(HealthRegistry::default()),
-        )
+        Self::with_resources(config, keys, limit, options, SharedResources::default())
     }
 
     /// Share this registry between generations to retain health for unchanged backends.
@@ -91,20 +95,26 @@ impl Runtime {
             keys,
             limit,
             options,
-            health,
-            Arc::new(RateRegistry::default()),
+            SharedResources {
+                health,
+                ..SharedResources::default()
+            },
         )
     }
 
-    /// Share registries across generations. Changing an active rate rule requires new resources.
+    /// Reuse registries across generations; changing retained limit rules requires new resources.
     pub fn with_resources(
         config: config::Config,
         keys: Arc<ApiKeys>,
         limit: ConcurrencyLimit,
         options: Options,
-        health: Arc<HealthRegistry>,
-        rates: Arc<RateRegistry>,
+        resources: SharedResources,
     ) -> Result<Self, BuildError> {
+        let SharedResources {
+            health,
+            rates,
+            quotas,
+        } = resources;
         config.validate().map_err(|_| BuildError)?;
         if options.request_timeout.is_zero()
             || Instant::now()
@@ -164,7 +174,18 @@ impl Runtime {
                     .map(|policy| rates.bind(id, policy).map(|rate| (id.clone(), rate)))
             })
             .collect::<Result<_, _>>()?;
+        let quotas = config
+            .models
+            .iter()
+            .filter_map(|(id, model)| {
+                model
+                    .quota
+                    .as_ref()
+                    .map(|policy| quotas.bind(id, policy).map(|quota| (id.clone(), quota)))
+            })
+            .collect::<Result<_, _>>()?;
         Ok(Self {
+            quotas,
             rates,
             health,
             models: config.models,
@@ -245,7 +266,9 @@ impl Runtime {
                 if downstream == ChatFormat::OpenAiResponses {
                     chat.openai.store = Some(false);
                 }
-                if chat.stream == Some(true) && downstream != ChatFormat::OpenAiChat {
+                if chat.stream == Some(true)
+                    && (downstream != ChatFormat::OpenAiChat || model.quota.is_some())
+                {
                     chat.openai
                         .stream_options
                         .get_or_insert(nyro_protocol::openai::chat::StreamOptions {
@@ -393,6 +416,20 @@ impl Runtime {
                 },
                 None => None,
             };
+            let mut quota = match self.quotas.get(&public_model) {
+                Some(bound) => match bound.reserve(&selected.backend.id) {
+                    Ok(reservation) => Some(reservation),
+                    Err(_) => {
+                        drop(exchange.permit.take());
+                        return Err(Failure::new(
+                            StatusCode::TOO_MANY_REQUESTS,
+                            "quota_exceeded",
+                            "Token quota cannot admit another attempt",
+                        ));
+                    }
+                },
+                None => None,
+            };
             exchange.backend = Some(selected.backend.id.clone());
             exchange.attempts += 1;
             let response = match selected
@@ -408,6 +445,9 @@ impl Runtime {
                     // Only connection establishment is known to precede sending the request.
                     if !error.is_connect() {
                         return Err(Failure::upstream());
+                    }
+                    if let Some(quota) = quota.take() {
+                        quota.release();
                     }
                     last_failure = Some(Failure::upstream());
                     continue;
@@ -447,6 +487,7 @@ impl Runtime {
                     &endpoint,
                     &request,
                     &mut health,
+                    &mut quota,
                 )
                 .await;
             if let Some(health) = health {

--- a/crates/nyro-llm/src/runtime/response.rs
+++ b/crates/nyro-llm/src/runtime/response.rs
@@ -5,6 +5,7 @@ use crate::{
     codec::{ChatFormat, anthropic, gemini, openai},
     health::Attempt,
     provider::Driver,
+    quota::AttemptQuota,
 };
 use axum::{
     body::Body,
@@ -21,6 +22,7 @@ impl Runtime {
         endpoint: &Endpoint,
         request: &Request,
         health: &mut Option<Attempt>,
+        quota: &mut Option<AttemptQuota>,
     ) -> Result<HttpResponse<Body>, Failure> {
         let streaming = request.is_streaming();
         let public_model = request.model().to_owned();
@@ -46,6 +48,7 @@ impl Runtime {
                 public_model,
                 self.options.max_frame_bytes,
                 include_usage,
+                quota.take(),
             );
             // Validate one complete frame before handing the response to HTTP. This is not a flush acknowledgement.
             let first = state.next_frame().await?.ok_or_else(Failure::upstream)?;
@@ -94,6 +97,14 @@ impl Runtime {
                     ChatFormat::Gemini => gemini::decode_chat_response(payload),
                 }
                 .map_err(|_| Failure::upstream())?;
+                if let Some(quota) = quota.as_mut()
+                    && let Some(usage) = response.usage.as_ref()
+                {
+                    quota.observe(usage).map_err(|_| Failure::upstream())?;
+                }
+                if let Some(quota) = quota.take() {
+                    quota.complete();
+                }
                 response.model = public_model;
                 match endpoint.format {
                     ChatFormat::OpenAiResponses => {
@@ -107,6 +118,14 @@ impl Runtime {
             Workload::Embedding => {
                 let mut response =
                     openai::decode_embedding_response(payload).map_err(|_| Failure::upstream())?;
+                if let Some(quota) = quota.as_mut() {
+                    quota
+                        .observe_embedding(&response.usage)
+                        .map_err(|_| Failure::upstream())?;
+                }
+                if let Some(quota) = quota.take() {
+                    quota.complete();
+                }
                 response.model = public_model;
                 openai::encode_embedding_response(&response)
             }

--- a/crates/nyro-llm/src/runtime/stream.rs
+++ b/crates/nyro-llm/src/runtime/stream.rs
@@ -2,6 +2,7 @@ use super::Failure;
 use crate::{
     ChatEvent,
     codec::{ChatFormat, CodecError, anthropic, gemini, openai},
+    quota::AttemptQuota,
 };
 use bytes::Bytes;
 use futures::{StreamExt, stream::BoxStream};
@@ -81,6 +82,7 @@ pub(super) struct StreamState {
     done: bool,
     eof: bool,
     max_bytes: usize,
+    quota: Option<AttemptQuota>,
 }
 impl StreamState {
     pub(super) fn new(
@@ -90,6 +92,7 @@ impl StreamState {
         model: String,
         max_bytes: usize,
         include_usage: bool,
+        quota: Option<AttemptQuota>,
     ) -> Self {
         let decoder = match upstream {
             ChatFormat::OpenAiChat => Decode::Openai { done: false },
@@ -127,12 +130,24 @@ impl StreamState {
             done: false,
             eof: false,
             max_bytes,
+            quota,
         }
     }
     pub(super) async fn next_frame(&mut self) -> Result<Option<String>, Failure> {
         loop {
             if let Some(event) = self.canonical.pop_front() {
+                if let Some(quota) = self.quota.as_mut()
+                    && let ChatEvent::Chunk(chunk) = &event
+                    && let Some(usage) = chunk.usage.as_ref()
+                {
+                    quota.observe(usage).map_err(|_| Failure::upstream())?;
+                }
                 self.done = event.is_done();
+                if self.done
+                    && let Some(quota) = self.quota.take()
+                {
+                    quota.complete();
+                }
                 let output = self.encoder.push(&event).map_err(|_| Failure::upstream())?;
                 if output.len() > self.max_bytes {
                     return Err(Failure::upstream());

--- a/crates/nyro-llm/tests/config.rs
+++ b/crates/nyro-llm/tests/config.rs
@@ -5,6 +5,49 @@ use nyro_llm::{
 use std::collections::{BTreeMap, BTreeSet};
 
 #[test]
+fn quota_policy_omission_disables_it_and_explicit_bounds_roundtrip() {
+    let value = serde_json::to_value(valid_config()).unwrap();
+    assert!(value["models"]["chat"].get("quota").is_none());
+    for policy in [
+        serde_json::json!({"total_tokens": 100, "reserve_tokens": 20}),
+        serde_json::json!({"total_tokens": u64::MAX, "reserve_tokens": u64::MAX}),
+    ] {
+        let mut enabled = value.clone();
+        enabled["models"]["chat"]["quota"] = policy.clone();
+        let config: Config = serde_json::from_value(enabled).expect("quota policy must load");
+        config.validate().unwrap();
+        assert_eq!(
+            serde_json::to_value(config).unwrap()["models"]["chat"]["quota"],
+            policy
+        );
+    }
+}
+
+#[test]
+fn quota_policy_rejects_missing_null_unknown_and_invalid_values() {
+    for policy in [
+        serde_json::json!(null),
+        serde_json::json!({}),
+        serde_json::json!({"total_tokens": 100}),
+        serde_json::json!({"reserve_tokens": 20}),
+        serde_json::json!({"total_tokens": 0, "reserve_tokens": 20}),
+        serde_json::json!({"total_tokens": 100, "reserve_tokens": 0}),
+        serde_json::json!({"total_tokens": 10, "reserve_tokens": 20}),
+        serde_json::json!({"total_tokens": -1, "reserve_tokens": 20}),
+        serde_json::json!({"total_tokens": 100, "reserve_tokens": -1}),
+        serde_json::json!({"total_tokens": null, "reserve_tokens": 20}),
+        serde_json::json!({"total_tokens": 100, "reserve_tokens": null}),
+        serde_json::json!({"total_tokens": 100, "reserve_tokens": 20, "unknown": true}),
+    ] {
+        let mut value = serde_json::to_value(valid_config()).unwrap();
+        value["models"]["chat"]["quota"] = policy.clone();
+        if let Ok(config) = serde_json::from_value::<Config>(value) {
+            assert!(config.validate().is_err(), "{policy}");
+        }
+    }
+}
+
+#[test]
 fn rate_policy_defaults_to_one_burst_and_omission_disables_it() {
     let value = serde_json::to_value(valid_config()).unwrap();
     assert!(value["models"]["chat"].get("rate").is_none());
@@ -33,6 +76,7 @@ fn valid_config() -> Config {
                 max_attempts: 1,
                 health: None,
                 rate: None,
+                quota: None,
                 backends: vec![Backend {
                     id: "default".into(),
                     provider: "openai".into(),

--- a/crates/nyro-llm/tests/quota_runtime.rs
+++ b/crates/nyro-llm/tests/quota_runtime.rs
@@ -1,0 +1,880 @@
+//! Cumulative token accounting against independent local HTTP wire fixtures.
+use axum::{
+    Router,
+    body::{Body, to_bytes},
+    http::{Request, Response, StatusCode},
+    routing::post,
+};
+use futures::StreamExt;
+use nyro_limit::ConcurrencyLimit;
+use nyro_llm::{
+    config::Config,
+    runtime::{Options, Runtime, SharedResources},
+};
+use nyro_security::{ApiKey, ApiKeys};
+use serde_json::{Value, json};
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use tokio_util::sync::CancellationToken;
+
+#[test]
+fn model_quota_configuration_is_accepted() {
+    let config = serde_json::from_value::<Config>(json!({
+        "providers":{"p":{"kind":"openai","base_url":"http://127.0.0.1:1/v1"}},
+        "models":{"public":{"provider":"p","upstream_model":"private","workloads":["chat"],
+            "quota":{"total_tokens":100,"reserve_tokens":10}}}
+    }));
+    assert!(config.is_ok(), "{config:?}");
+}
+
+#[derive(Clone)]
+enum Reply {
+    Json(Value),
+    Sse(String, bool),
+    Status(u16),
+    Slow,
+}
+struct Upstream {
+    base: String,
+    calls: Arc<Mutex<Vec<Value>>>,
+    reply: Arc<Mutex<Reply>>,
+    task: tokio::task::JoinHandle<()>,
+}
+impl Upstream {
+    fn count(&self) -> usize {
+        self.calls.lock().unwrap().len()
+    }
+    async fn wait_for_call(&self) {
+        tokio::time::timeout(Duration::from_secs(3), async {
+            while self.count() == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("upstream receives admitted request");
+    }
+}
+impl Drop for Upstream {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+async fn upstream(reply: Reply) -> Upstream {
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let replies = Arc::new(Mutex::new(reply));
+    let observed = calls.clone();
+    let configured = replies.clone();
+    let app = Router::new().fallback(post(move |request: Request<Body>| {
+        let observed = observed.clone();
+        let configured = configured.clone();
+        async move {
+            let body: Value =
+                serde_json::from_slice(&to_bytes(request.into_body(), 16384).await.unwrap())
+                    .unwrap();
+            observed.lock().unwrap().push(body);
+            let reply = configured.lock().unwrap().clone();
+            let (status, content_type, body) = match reply {
+                Reply::Json(value) => (200, "application/json", Body::from(value.to_string())),
+                Reply::Status(status) => (
+                    status,
+                    "application/json",
+                    Body::from("private upstream-secret failure"),
+                ),
+                Reply::Slow => {
+                    tokio::time::sleep(Duration::from_secs(30)).await;
+                    (200, "application/json", Body::empty())
+                }
+                Reply::Sse(text, hang) => {
+                    // Arbitrary transport chunks must not affect usage snapshots.
+                    let chunks: Vec<_> = text
+                        .as_bytes()
+                        .chunks(17)
+                        .map(|b| Ok::<_, std::io::Error>(b.to_vec()))
+                        .collect();
+                    let source = futures::stream::iter(chunks);
+                    let source = if hang {
+                        source.chain(futures::stream::pending()).boxed()
+                    } else {
+                        source.boxed()
+                    };
+                    (200, "text/event-stream", Body::from_stream(source))
+                }
+            };
+            Response::builder()
+                .status(status)
+                .header("content-type", content_type)
+                .body(body)
+                .unwrap()
+        }
+    }));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    let task = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    Upstream {
+        base,
+        calls,
+        reply: replies,
+        task,
+    }
+}
+fn native(format: &str) -> Value {
+    match format {
+        "openai" => {
+            json!({"id":"answer","object":"chat.completion","created":1,"model":"private","choices":[{"index":0,"message":{"role":"assistant","content":"Hello"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}})
+        }
+        "anthropic" => {
+            json!({"id":"answer","type":"message","role":"assistant","model":"private","content":[{"type":"text","text":"Hello"}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":3,"output_tokens":2}})
+        }
+        "gemini" => {
+            json!({"responseId":"answer","modelVersion":"private","candidates":[{"index":0,"content":{"role":"model","parts":[{"text":"Hello"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":2,"totalTokenCount":5}})
+        }
+        "responses" => {
+            json!({"id":"answer","object":"response","created_at":1,"model":"private","status":"completed","error":null,"incomplete_details":null,"output":[{"type":"message","id":"msg","role":"assistant","status":"completed","content":[{"type":"output_text","text":"Hello","annotations":[]}]}],"usage":{"input_tokens":3,"output_tokens":2,"total_tokens":5}})
+        }
+        _ => panic!("unknown fixture"),
+    }
+}
+fn chat_frames(totals: &[u64], done: bool) -> String {
+    let first = json!({"id":"answer","object":"chat.completion.chunk","created":1,"model":"private","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"},"finish_reason":null}]});
+    let mut text = format!("data: {first}\n\n");
+    for total in totals {
+        let usage = json!({"id":"answer","object":"chat.completion.chunk","created":1,"model":"private","choices":[],"usage":{"prompt_tokens":0,"completion_tokens":total,"total_tokens":total}});
+        text.push_str(&format!("data: {usage}\n\n"));
+    }
+    if done {
+        let finish = json!({"id":"answer","object":"chat.completion.chunk","created":1,"model":"private","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]});
+        text.push_str(&format!("data: {finish}\n\ndata: [DONE]\n\n"));
+    }
+    text
+}
+fn native_frames(format: &str) -> String {
+    match format {
+        "openai" => chat_frames(&[3, 5, 5], true),
+        "anthropic" => concat!(
+            "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"answer\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"private\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":3,\"output_tokens\":0}}}\n\n",
+            "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+            "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n\n",
+            "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+            "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"output_tokens\":2}}\n\n",
+            "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+        ).into(),
+        "gemini" => format!("data: {}\n\n", native("gemini")),
+        "responses" => {
+            let terminal = native("responses");
+            let mut start = terminal.clone();
+            start["status"] = json!("in_progress"); start["output"] = json!([]); start["usage"] = Value::Null;
+            let events = [
+                json!({"type":"response.created","response":start}),
+                json!({"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"msg","role":"assistant","status":"in_progress","content":[]}}),
+                json!({"type":"response.content_part.added","output_index":0,"content_index":0,"item_id":"msg","part":{"type":"output_text","text":"","annotations":[]}}),
+                json!({"type":"response.output_text.delta","output_index":0,"content_index":0,"item_id":"msg","delta":"Hello"}),
+                json!({"type":"response.output_text.done","output_index":0,"content_index":0,"item_id":"msg","text":"Hello"}),
+                json!({"type":"response.content_part.done","output_index":0,"content_index":0,"item_id":"msg","part":terminal["output"][0]["content"][0]}),
+                json!({"type":"response.output_item.done","output_index":0,"item":terminal["output"][0]}),
+                json!({"type":"response.completed","response":terminal}),
+            ];
+            events.into_iter().enumerate().map(|(i, mut event)| { event["sequence_number"] = json!(i); format!("event: {}\ndata: {event}\n\n", event["type"].as_str().unwrap()) }).collect()
+        }
+        _ => panic!("unknown fixture"),
+    }
+}
+fn configuration(upstreams: &[&Upstream], format: &str, total: u64, reserve: u64) -> Config {
+    let providers: serde_json::Map<_, _> = upstreams.iter().enumerate().map(|(i, u)| {
+        let mut value = json!({"kind":if format == "responses" {"openai"} else {format},"base_url":format!("{}/{}",u.base, if format == "gemini" {"v1beta"} else {"v1"}),"api_key":"upstream-secret"});
+        if format == "responses" { value["api"] = json!("responses"); }
+        (format!("p{i}"), value)
+    }).collect();
+    let backends: Vec<_> = upstreams.iter().enumerate().map(|(i, _)| json!({"id":format!("b{i}"),"provider":format!("p{i}"),"upstream_model":"private","priority":i})).collect();
+    serde_json::from_value(json!({"providers":providers,"models":{"public":{"backends":backends,"max_attempts":upstreams.len(),"workloads":if format == "openai" {json!(["chat","embedding"])} else {json!(["chat"])},"subjects":["alice","bob"],"allow_anonymous":true,"quota":{"total_tokens":total,"reserve_tokens":reserve}}}})).unwrap()
+}
+fn runtime(
+    config: Config,
+    limit: &ConcurrencyLimit,
+    options: Options,
+    resources: &SharedResources,
+) -> Runtime {
+    Runtime::with_resources(
+        config,
+        Arc::new(
+            ApiKeys::new(vec![
+                ApiKey {
+                    id: "alice".into(),
+                    secret: "alice-secret".into(),
+                },
+                ApiKey {
+                    id: "bob".into(),
+                    secret: "bob-secret".into(),
+                },
+            ])
+            .unwrap(),
+        ),
+        limit.clone(),
+        options,
+        resources.clone(),
+    )
+    .unwrap()
+}
+fn request(format: &str, streaming: bool) -> Request<Body> {
+    let (path, body) = match format {
+        "openai" => (
+            "/v1/chat/completions".into(),
+            json!({"model":"public","messages":[{"role":"user","content":"Hi"}],"max_tokens":16,"stream":streaming}),
+        ),
+        "responses" => (
+            "/v1/responses".into(),
+            json!({"model":"public","input":"Hi","max_output_tokens":16,"stream":streaming}),
+        ),
+        "anthropic" => (
+            "/v1/messages".into(),
+            json!({"model":"public","messages":[{"role":"user","content":"Hi"}],"max_tokens":16,"stream":streaming}),
+        ),
+        "embedding" => (
+            "/v1/embeddings".into(),
+            json!({"model":"public","input":"Hi"}),
+        ),
+        _ => (
+            format!(
+                "/v1beta/models/public:{}",
+                if streaming {
+                    "streamGenerateContent?alt=sse"
+                } else {
+                    "generateContent"
+                }
+            ),
+            json!({"contents":[{"role":"user","parts":[{"text":"Hi"}]}],"generationConfig":{"maxOutputTokens":16}}),
+        ),
+    };
+    Request::builder()
+        .method("POST")
+        .uri(path)
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+async fn invoke(runtime: &Runtime) -> Response<Body> {
+    runtime
+        .handle(request("openai", false), CancellationToken::new())
+        .await
+}
+fn balance(resources: &SharedResources, used: u128, reserved: u64) {
+    let value = resources.quotas.snapshot("public").expect("bound quota");
+    assert_eq!((value.used, value.reserved), (used, reserved));
+}
+async fn consume(response: Response<Body>) -> Value {
+    serde_json::from_slice(&to_bytes(response.into_body(), 65536).await.unwrap()).unwrap()
+}
+async fn assert_quota(response: Response<Body>) {
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert!(!response.headers().contains_key("retry-after"));
+    let value = consume(response).await;
+    assert_eq!(value["error"]["code"], "quota_exceeded");
+    assert!(!value.to_string().contains("private") && !value.to_string().contains("secret"));
+}
+
+#[tokio::test]
+async fn json_settles_before_body_handoff_including_zero_missing_invalid_and_overage() {
+    for (usage, status, charged) in [
+        (
+            json!({"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}),
+            200,
+            5,
+        ),
+        (
+            json!({"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}),
+            200,
+            0,
+        ),
+        (Value::Null, 200, 10),
+        (
+            json!({"prompt_tokens":3,"completion_tokens":2,"total_tokens":4}),
+            502,
+            10,
+        ),
+        (
+            json!({"prompt_tokens":u64::MAX,"completion_tokens":1,"total_tokens":0}),
+            502,
+            10,
+        ),
+        (
+            json!({"prompt_tokens":11,"completion_tokens":12,"total_tokens":23}),
+            200,
+            23,
+        ),
+    ] {
+        let mut value = native("openai");
+        if usage.is_null() {
+            value.as_object_mut().unwrap().remove("usage");
+        } else {
+            value["usage"] = usage;
+        }
+        let upstream = upstream(Reply::Json(value)).await;
+        let resources = SharedResources::default();
+        let limit = ConcurrencyLimit::new(1).unwrap();
+        let runtime = runtime(
+            configuration(&[&upstream], "openai", 20, 10),
+            &limit,
+            Options::default(),
+            &resources,
+        );
+        let response = invoke(&runtime).await;
+        assert_eq!(response.status().as_u16(), status);
+        balance(&resources, charged, 0);
+        drop(response);
+        assert_eq!(limit.available(), 1);
+        if charged > 20 {
+            assert_quota(invoke(&runtime).await).await;
+            assert_eq!(upstream.count(), 1);
+        }
+    }
+}
+
+#[tokio::test]
+async fn native_json_and_streams_share_actual_usage_across_ingress_protocols_and_callers() {
+    for format in ["openai", "anthropic", "gemini", "responses"] {
+        let upstream = upstream(Reply::Json(native(format))).await;
+        let resources = SharedResources::default();
+        let runtime = runtime(
+            configuration(&[&upstream], format, 100, 10),
+            &ConcurrencyLimit::new(1).unwrap(),
+            Options::default(),
+            &resources,
+        );
+        for (i, ingress) in ["openai", "anthropic", "gemini", "responses"]
+            .into_iter()
+            .enumerate()
+        {
+            let mut input = request(ingress, false);
+            if i % 2 == 0 {
+                input
+                    .headers_mut()
+                    .insert("authorization", "Bearer bob-secret".parse().unwrap());
+            }
+            let response = runtime.handle(input, CancellationToken::new()).await;
+            assert_eq!(response.status(), StatusCode::OK, "{format}/{ingress}");
+            balance(&resources, 5 * (i as u128 + 1), 0);
+            consume(response).await;
+        }
+        *upstream.reply.lock().unwrap() = Reply::Sse(native_frames(format), false);
+        for (i, ingress) in ["openai", "anthropic", "gemini", "responses"]
+            .into_iter()
+            .enumerate()
+        {
+            let response = runtime
+                .handle(request(ingress, true), CancellationToken::new())
+                .await;
+            assert_eq!(response.status(), StatusCode::OK, "{format}/{ingress}");
+            let bytes = to_bytes(response.into_body(), 65536).await.unwrap();
+            assert!(
+                String::from_utf8_lossy(&bytes).contains("Hello"),
+                "{format}/{ingress}"
+            );
+            balance(&resources, 25 + 5 * i as u128, 0);
+        }
+        assert_eq!(upstream.count(), 8);
+    }
+}
+
+#[tokio::test]
+async fn embedding_charges_input_tokens_and_rejects_inconsistent_usage() {
+    let upstream = upstream(Reply::Json(json!({"object":"list","model":"private","data":[{"object":"embedding","index":0,"embedding":[0.25]}],"usage":{"prompt_tokens":3,"total_tokens":3}}))).await;
+    let resources = SharedResources::default();
+    let runtime = runtime(
+        configuration(&[&upstream], "openai", 30, 10),
+        &ConcurrencyLimit::new(1).unwrap(),
+        Options::default(),
+        &resources,
+    );
+    let response = runtime
+        .handle(request("embedding", false), CancellationToken::new())
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    balance(&resources, 3, 0);
+    drop(response);
+    if let Reply::Json(value) = &mut *upstream.reply.lock().unwrap() {
+        value["usage"]["total_tokens"] = json!(4);
+    }
+    let response = runtime
+        .handle(request("embedding", false), CancellationToken::new())
+        .await;
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    balance(&resources, 13, 0);
+}
+
+#[tokio::test]
+async fn upstream_usage_is_forced_but_downstream_visibility_follows_caller() {
+    let upstream = upstream(Reply::Sse(chat_frames(&[3, 5, 5], true), false)).await;
+    let resources = SharedResources::default();
+    let runtime = runtime(
+        configuration(&[&upstream], "openai", 100, 10),
+        &ConcurrencyLimit::new(1).unwrap(),
+        Options::default(),
+        &resources,
+    );
+    for visible in [false, true] {
+        let mut input = request("openai", true);
+        if visible {
+            let mut body: Value = serde_json::from_slice(
+                &to_bytes(std::mem::replace(input.body_mut(), Body::empty()), 16384)
+                    .await
+                    .unwrap(),
+            )
+            .unwrap();
+            body["stream_options"] = json!({"include_usage":true});
+            *input.body_mut() = Body::from(body.to_string());
+        }
+        let response = runtime.handle(input, CancellationToken::new()).await;
+        let bytes = to_bytes(response.into_body(), 65536).await.unwrap();
+        let text = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(text.contains("[DONE]"));
+        assert_eq!(text.contains("\"total_tokens\""), visible);
+        assert_eq!(
+            upstream.calls.lock().unwrap().last().unwrap()["stream_options"]["include_usage"],
+            true
+        );
+    }
+    balance(&resources, 10, 0);
+}
+
+#[tokio::test]
+async fn each_retry_reserves_again_and_quota_denial_stops_failover() {
+    for total in [10, 20] {
+        let first = upstream(Reply::Status(503)).await;
+        let backup = upstream(Reply::Json(native("openai"))).await;
+        let resources = SharedResources::default();
+        let limit = ConcurrencyLimit::new(1).unwrap();
+        let runtime = runtime(
+            configuration(&[&first, &backup], "openai", total, 10),
+            &limit,
+            Options::default(),
+            &resources,
+        );
+        let response = invoke(&runtime).await;
+        if total == 10 {
+            assert_eq!(limit.available(), 1);
+            assert_quota(response).await;
+            balance(&resources, 10, 0);
+            assert_eq!(backup.count(), 0);
+        } else {
+            assert_eq!(response.status(), StatusCode::OK);
+            balance(&resources, 15, 0);
+            drop(response);
+            assert_eq!(backup.count(), 1);
+        }
+        assert_eq!(first.count(), 1);
+    }
+}
+
+#[tokio::test]
+async fn known_connect_failure_refunds_reservation_for_backup() {
+    let first = upstream(Reply::Json(native("openai"))).await;
+    let backup = upstream(Reply::Json(native("openai"))).await;
+    // Hold an unlistened local socket address only until configuration is built.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let mut config = configuration(&[&first, &backup], "openai", 10, 10);
+    config.providers.get_mut("p0").unwrap().base_url =
+        format!("http://{}/v1", listener.local_addr().unwrap());
+    drop(listener);
+    let resources = SharedResources::default();
+    let runtime = runtime(
+        config,
+        &ConcurrencyLimit::new(1).unwrap(),
+        Options::default(),
+        &resources,
+    );
+    let response = invoke(&runtime).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    balance(&resources, 5, 0);
+    assert_eq!((first.count(), backup.count()), (0, 1));
+}
+
+#[tokio::test]
+async fn concurrent_pending_streams_hold_reservations_and_denial_releases_permit() {
+    let upstream = upstream(Reply::Sse(chat_frames(&[], false), true)).await;
+    let resources = SharedResources::default();
+    let limit = ConcurrencyLimit::new(3).unwrap();
+    let runtime = runtime(
+        configuration(&[&upstream], "openai", 20, 10),
+        &limit,
+        Options::default(),
+        &resources,
+    );
+    let (a, b) = tokio::join!(
+        runtime.handle(request("openai", true), CancellationToken::new()),
+        runtime.handle(request("openai", true), CancellationToken::new())
+    );
+    assert_eq!(a.status(), StatusCode::OK);
+    assert_eq!(b.status(), StatusCode::OK);
+    balance(&resources, 0, 20);
+    let denied = invoke(&runtime).await;
+    assert_eq!(limit.available(), 1);
+    balance(&resources, 0, 20);
+    assert_quota(denied).await;
+    drop(a);
+    balance(&resources, 10, 10);
+    drop(b);
+    balance(&resources, 20, 0);
+    assert_eq!(limit.available(), 3);
+    assert_eq!(upstream.count(), 2);
+}
+
+#[tokio::test]
+async fn stream_truncation_drop_cancel_and_timeout_charge_highest_observed_or_reservation() {
+    for observed in [3, 23] {
+        for ending in ["truncate", "drop", "cancel", "timeout"] {
+            let upstream = upstream(Reply::Sse(
+                chat_frames(&[observed], false),
+                ending != "truncate",
+            ))
+            .await;
+            let resources = SharedResources::default();
+            let limit = ConcurrencyLimit::new(1).unwrap();
+            let runtime = runtime(
+                configuration(&[&upstream], "openai", 20, 10),
+                &limit,
+                Options {
+                    request_timeout: Duration::from_millis(if ending == "timeout" {
+                        300
+                    } else {
+                        5000
+                    }),
+                    ..Options::default()
+                },
+                &resources,
+            );
+            let token = CancellationToken::new();
+            let mut input = request("openai", true);
+            let mut value: Value = serde_json::from_slice(
+                &to_bytes(std::mem::replace(input.body_mut(), Body::empty()), 16384)
+                    .await
+                    .unwrap(),
+            )
+            .unwrap();
+            value["stream_options"] = json!({"include_usage":true});
+            *input.body_mut() = Body::from(value.to_string());
+            let response = runtime.handle(input, token.clone()).await;
+            assert_eq!(response.status(), StatusCode::OK);
+            let mut stream = response.into_body().into_data_stream();
+            let mut text = String::new();
+            while !text.contains("\"total_tokens\"") {
+                text.push_str(&String::from_utf8_lossy(
+                    &stream.next().await.unwrap().unwrap(),
+                ));
+            }
+            balance(&resources, 0, 10);
+            if ending == "drop" {
+                drop(stream);
+            } else {
+                if ending == "cancel" {
+                    token.cancel();
+                }
+                let mut failed = false;
+                while let Some(chunk) = stream.next().await {
+                    if chunk.is_err() {
+                        failed = true;
+                        break;
+                    }
+                }
+                assert!(failed, "{ending}/{observed}");
+                drop(stream);
+            }
+            balance(&resources, u128::from(observed.max(10)), 0);
+            assert_eq!(limit.available(), 1);
+            if observed > 20 {
+                assert_quota(invoke(&runtime).await).await;
+                assert_eq!(upstream.count(), 1);
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn decreasing_stream_usage_is_invalid_and_preserves_highest_observation() {
+    let upstream = upstream(Reply::Sse(chat_frames(&[23, 5], true), false)).await;
+    let resources = SharedResources::default();
+    let runtime = runtime(
+        configuration(&[&upstream], "openai", 20, 10),
+        &ConcurrencyLimit::new(1).unwrap(),
+        Options::default(),
+        &resources,
+    );
+    let response = runtime
+        .handle(request("openai", true), CancellationToken::new())
+        .await;
+    assert!(to_bytes(response.into_body(), 65536).await.is_err());
+    balance(&resources, 23, 0);
+    assert_quota(invoke(&runtime).await).await;
+}
+
+#[tokio::test]
+async fn cancellation_or_future_drop_after_dispatch_charges_reservation() {
+    for cancel in [false, true] {
+        let upstream = upstream(Reply::Slow).await;
+        let resources = SharedResources::default();
+        let limit = ConcurrencyLimit::new(1).unwrap();
+        let runtime = runtime(
+            configuration(&[&upstream], "openai", 10, 10),
+            &limit,
+            Options::default(),
+            &resources,
+        );
+        let token = CancellationToken::new();
+        let mut future = Box::pin(runtime.handle(request("openai", false), token.clone()));
+        tokio::select! { _ = &mut future => panic!("provider waits"), _ = upstream.wait_for_call() => {} }
+        balance(&resources, 0, 10);
+        if cancel {
+            token.cancel();
+            assert_eq!(future.await.status(), StatusCode::SERVICE_UNAVAILABLE);
+        } else {
+            drop(future);
+        }
+        balance(&resources, 10, 0);
+        assert_eq!(limit.available(), 1);
+        assert_quota(invoke(&runtime).await).await;
+    }
+}
+
+#[tokio::test]
+async fn no_network_admission_and_unhealthy_backends_do_not_charge_quota() {
+    let upstream = upstream(Reply::Status(503)).await;
+    let resources = SharedResources::default();
+    let limit = ConcurrencyLimit::new(1).unwrap();
+    let mut config = configuration(&[&upstream], "openai", 30, 10);
+    config.models.get_mut("public").unwrap().health = Some(nyro_llm::config::HealthConfig {
+        failure_threshold: 1,
+        cooldown_ms: 60000,
+    });
+    config.models.get_mut("public").unwrap().allow_anonymous = false;
+    let runtime = runtime(config, &limit, Options::default(), &resources);
+    let denied = invoke(&runtime).await;
+    assert_eq!(denied.status(), StatusCode::UNAUTHORIZED);
+    drop(denied);
+    let mut input = request("openai", false);
+    input
+        .headers_mut()
+        .insert("authorization", "Bearer alice-secret".parse().unwrap());
+    let permit = limit.try_acquire().unwrap();
+    let response = runtime.handle(input, CancellationToken::new()).await;
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    drop(response);
+    drop(permit);
+    balance(&resources, 0, 0);
+    assert_eq!(upstream.count(), 0);
+    for _ in 0..2 {
+        let mut input = request("openai", false);
+        input
+            .headers_mut()
+            .insert("authorization", "Bearer alice-secret".parse().unwrap());
+        let response = runtime.handle(input, CancellationToken::new()).await;
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        drop(response);
+        balance(&resources, 10, 0);
+    }
+    assert_eq!(upstream.count(), 1);
+}
+
+#[tokio::test]
+async fn shared_generations_and_removal_preserve_consumed_balance() {
+    let upstream = upstream(Reply::Json(native("openai"))).await;
+    let resources = SharedResources::default();
+    let limit = ConcurrencyLimit::new(2).unwrap();
+    let config = configuration(&[&upstream], "openai", 20, 10);
+    let old = runtime(config.clone(), &limit, Options::default(), &resources);
+    let next = runtime(config.clone(), &limit, Options::default(), &resources);
+    drop(invoke(&old).await);
+    drop(invoke(&next).await);
+    balance(&resources, 10, 0);
+    drop(old);
+    drop(next);
+    let mut absent = config.clone();
+    let mut other = absent.models.remove("public").unwrap();
+    other.quota = None;
+    absent.models.insert("other".into(), other);
+    drop(runtime(absent, &limit, Options::default(), &resources));
+    balance(&resources, 10, 0);
+    let restored = runtime(config, &limit, Options::default(), &resources);
+    drop(invoke(&restored).await);
+    balance(&resources, 15, 0);
+    assert_quota(invoke(&restored).await).await;
+    assert_eq!(upstream.count(), 3);
+}
+
+#[tokio::test]
+async fn completed_stream_settles_zero_or_overage_before_terminal_delivery() {
+    for actual in [0, 23] {
+        let upstream = upstream(Reply::Sse(chat_frames(&[actual], true), false)).await;
+        let resources = SharedResources::default();
+        let runtime = runtime(
+            configuration(&[&upstream], "openai", 20, 10),
+            &ConcurrencyLimit::new(1).unwrap(),
+            Options::default(),
+            &resources,
+        );
+        let response = runtime
+            .handle(request("openai", true), CancellationToken::new())
+            .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let mut stream = response.into_body().into_data_stream();
+        loop {
+            let chunk = stream.next().await.expect("terminal must arrive").unwrap();
+            if String::from_utf8_lossy(&chunk).contains("[DONE]") {
+                break;
+            }
+        }
+        balance(&resources, u128::from(actual), 0);
+        drop(stream);
+        balance(&resources, u128::from(actual), 0);
+        if actual > 20 {
+            assert_quota(invoke(&runtime).await).await;
+        }
+    }
+}
+
+#[tokio::test]
+async fn rate_admission_precedes_quota_and_protocol_errors_preserve_native_shape() {
+    let upstream = upstream(Reply::Json(native("openai"))).await;
+    let resources = SharedResources::default();
+    let limit = ConcurrencyLimit::new(1).unwrap();
+    let mut config = configuration(&[&upstream], "openai", 10, 10);
+    config.models.get_mut("public").unwrap().rate = Some(nyro_llm::config::RateConfig {
+        requests: 1,
+        period_ms: 60000,
+        burst: 2,
+    });
+    let limited = runtime(config, &limit, Options::default(), &resources);
+    drop(invoke(&limited).await);
+    balance(&resources, 5, 0);
+    let denied = invoke(&limited).await;
+    assert_eq!(limit.available(), 1);
+    assert_quota(denied).await;
+    let denied = invoke(&limited).await;
+    assert_eq!(denied.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert!(denied.headers().contains_key("retry-after"));
+    assert_eq!(
+        consume(denied).await["error"]["code"],
+        "rate_limit_exceeded"
+    );
+    balance(&resources, 5, 0);
+    assert_eq!(upstream.count(), 1);
+
+    let resources = SharedResources::default();
+    let runtime = runtime(
+        configuration(&[&upstream], "openai", 10, 10),
+        &limit,
+        Options::default(),
+        &resources,
+    );
+    drop(invoke(&runtime).await);
+    for format in ["openai", "responses", "anthropic", "gemini"] {
+        let denied = runtime
+            .handle(request(format, false), CancellationToken::new())
+            .await;
+        assert_eq!(denied.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert!(!denied.headers().contains_key("retry-after"));
+        assert_eq!(limit.available(), 1);
+        let body = consume(denied).await;
+        match format {
+            "anthropic" => {
+                assert_eq!(body["type"], "error");
+                assert_eq!(body["error"]["type"], "rate_limit_error");
+            }
+            "gemini" => {
+                assert_eq!(body["error"]["code"], 429);
+                assert_eq!(body["error"]["status"], "RESOURCE_EXHAUSTED");
+            }
+            _ => assert_eq!(body["error"]["code"], "quota_exceeded"),
+        }
+    }
+    balance(&resources, 5, 0);
+    assert_eq!(upstream.count(), 2);
+}
+
+#[tokio::test]
+async fn invalid_requests_pre_dispatch_cancellation_and_body_timeout_leave_quota_empty() {
+    let upstream = upstream(Reply::Json(native("openai"))).await;
+    let resources = SharedResources::default();
+    let limit = ConcurrencyLimit::new(1).unwrap();
+    let runtime = runtime(
+        configuration(&[&upstream], "openai", 10, 10),
+        &limit,
+        Options {
+            request_timeout: Duration::from_millis(300),
+            ..Options::default()
+        },
+        &resources,
+    );
+    let mut invalid = request("openai", false);
+    *invalid.body_mut() = Body::from(r#"{"model":"public","messages":false}"#);
+    assert_eq!(
+        runtime
+            .handle(invalid, CancellationToken::new())
+            .await
+            .status(),
+        StatusCode::BAD_REQUEST
+    );
+    let cancelled = CancellationToken::new();
+    cancelled.cancel();
+    assert_eq!(
+        runtime
+            .handle(request("openai", false), cancelled)
+            .await
+            .status(),
+        StatusCode::SERVICE_UNAVAILABLE
+    );
+    let mut pending = request("openai", false);
+    *pending.body_mut() =
+        Body::from_stream(futures::stream::pending::<Result<Vec<u8>, std::io::Error>>());
+    assert_eq!(
+        runtime
+            .handle(pending, CancellationToken::new())
+            .await
+            .status(),
+        StatusCode::GATEWAY_TIMEOUT
+    );
+    balance(&resources, 0, 0);
+    assert_eq!(upstream.count(), 0);
+    assert_eq!(limit.available(), 1);
+    assert_eq!(invoke(&runtime).await.status(), StatusCode::OK);
+    balance(&resources, 5, 0);
+}
+
+#[tokio::test]
+async fn aliases_have_independent_quotas_and_omission_disables_accounting() {
+    let upstream = upstream(Reply::Json(native("openai"))).await;
+    let resources = SharedResources::default();
+    let mut config = configuration(&[&upstream], "openai", 10, 10);
+    config
+        .models
+        .insert("other".into(), config.models["public"].clone());
+    let mut unlimited = config.models["public"].clone();
+    unlimited.quota = None;
+    config.models.insert("unlimited".into(), unlimited);
+    let runtime = runtime(
+        config,
+        &ConcurrencyLimit::new(1).unwrap(),
+        Options::default(),
+        &resources,
+    );
+    drop(invoke(&runtime).await);
+    assert_quota(invoke(&runtime).await).await;
+    for alias in ["other", "unlimited", "unlimited"] {
+        let mut input = request("openai", false);
+        *input.body_mut() = Body::from(
+            json!({"model":alias,"messages":[{"role":"user","content":"Hi"}]}).to_string(),
+        );
+        assert_eq!(
+            runtime
+                .handle(input, CancellationToken::new())
+                .await
+                .status(),
+            StatusCode::OK
+        );
+    }
+    balance(&resources, 5, 0);
+    assert_eq!(resources.quotas.snapshot("other").unwrap().used, 5);
+    assert!(resources.quotas.snapshot("unlimited").is_none());
+    assert_eq!(upstream.count(), 4);
+}

--- a/crates/nyro-llm/tests/runtime.rs
+++ b/crates/nyro-llm/tests/runtime.rs
@@ -91,6 +91,7 @@ fn runtime(upstream: &Upstream, limit: ConcurrencyLimit, options: Options) -> Ru
                 max_attempts: 1,
                 health: None,
                 rate: None,
+                quota: None,
                 backends: vec![config::Backend {
                     id: "default".into(),
                     provider: "upstream".into(),

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -4,7 +4,7 @@
 >
 > 本文是本轮 Rust 重构的目标架构依据，不代表代码已完成迁移。目录树、Rust 类型示例和命令形态均为目标设计；当前实现请查看[现有 workspace](../../Cargo.toml)和本文的现状对应表。
 
-当前已落地独立的 [`nyro-kernel`](../../crates/nyro-kernel/README_CN.md)，以及使用它的实验性源码构建根命令 [`nyro proxy --config`](../standalone/rust-proxy_CN.md)。该命令实现严格文件配置、OpenAI Chat/Embedding、无状态 Responses、Anthropic/Gemini Chat 与跨协议 SSE 子集、多 backend 优先级／加权选择与有界故障转移、认证授权、共享并发限制、模型请求频率限制和代际 lease。现有 `nyro-core`、已发布 Server 和 Tauri 请求路径尚未接入该内核；`nyro serve`、`nyro tool`、控制面和其余目标能力仍未实现。
+当前已落地独立的 [`nyro-kernel`](../../crates/nyro-kernel/README_CN.md)，以及使用它的实验性源码构建根命令 [`nyro proxy --config`](../standalone/rust-proxy_CN.md)。该命令实现严格文件配置、OpenAI Chat/Embedding、无状态 Responses、Anthropic/Gemini Chat 与跨协议 SSE 子集、多 backend 优先级／加权选择与有界故障转移、认证授权、共享并发限制、模型请求频率限制、累计 token 额度和代际 lease。现有 `nyro-core`、已发布 Server 和 Tauri 请求路径尚未接入该内核；`nyro serve`、`nyro tool`、控制面和其余目标能力仍未实现。
 
 ## 1. 产品定位与范围
 
@@ -512,6 +512,10 @@ Chat 流使用自己的事件类型，不要求所有交互实现流接口。当
 当前 rate 实现是 `nyro-limit` 内不含业务键的可克隆令牌桶；LLM 按公开模型映射并共享状态，根程序显式持有跨代际注册表。持续频率与突发容量由模型的可选 `rate` 配置声明。一次逻辑请求在鉴权、并发准入和兼容性准备之后扣减一次，内部重试不重复计数，扣减后失败或取消不退款。超限返回原生协议 `429` 与向上取整的 `Retry-After`，立即释放并发许可。规则不变时配置重建保留余额；已有活跃规则的参数变更要求重启，避免候选构建意外重置计数。当前为进程内频率控制，不提供跨进程共享或持久化；具体语义见 [Rust proxy 指南](../standalone/rust-proxy_CN.md)。
 
 严格累计限额需要考虑并发预留与结算，单纯事前读计数、事后累加不能承诺硬上限。额度状态与并发许可的存储契约必须表达所需的原子性，不能用普通 KV 的 get/set 假定事务成立。
+
+当前 quota 实现为 `nyro-limit` 中按通用单位原子预留与结算的进程内账本，`nyro-llm` 将其映射到公开模型的累计输入加输出 token。模型可选配置 `quota.total_tokens` 与 `quota.reserve_tokens`，每次实际上游尝试前独立预留；完整 JSON／SSE 协议终止后按有效用量结算，连接建立失败全额释放，其他失败、取消、断流和用量缺失按预留与有效已知用量的较大值扣减。上游实际消耗可以超过预留，超额如实记账并阻止后续准入；配置预留不是可信的消耗上界，当前不承诺真实上游 token 硬上限，也不提供金额、持久化或多副本协调。
+
+根程序通过 `nyro_llm::runtime::SharedResources` 显式共享健康、rate 和 quota 注册表。quota 已消耗及在途账本在模型移除／加回后继续保留；有活跃绑定或已消费余额时修改规则会拒绝候选构建，避免配置变更清零。进程重启会重置进程内状态。quota 超限返回原生协议 `429`，不带 `Retry-After` 并立即释放并发许可；其之前的 rate 准入不退款。计量、协议映射和资源组合均未进入 `nyro-kernel`。
 
 观测初始化与资源装配由根程序协调。共享观测实现不认识模型数据库表；控制面的历史日志和统计读取归其业务存储。配置代际租约与限流并发许可是不同概念，不能复用一个计数器代替二者。
 

--- a/docs/standalone/rust-proxy.md
+++ b/docs/standalone/rust-proxy.md
@@ -44,6 +44,7 @@ Each model declares:
 - `max_attempts`: positive integer, default `1`, including the first upstream send. Each backend ID is attempted at most once per request.
 - `health`: optional passive breaker policy, disabled when omitted. An empty object enables `failure_threshold: 3` and `cooldown_ms: 30000`; both must be positive.
 - `rate`: optional per-model request frequency; omitted means disabled. See [Request rate](#request-rate).
+- `quota`: optional cumulative model token budget; omitted means disabled. See [Token quota](#token-quota).
 - `workloads`: a nonempty, duplicate-free list containing `chat`, `embedding`, or both when every backend uses OpenAI Chat Completions; Responses, Anthropic, and Gemini support only `chat`. Every backend, including disabled entries, must support the model's declared workloads. Invalid combinations fail startup.
 - `allow_anonymous`: optional, default `false`.
 - `subjects`: client credential IDs allowed to invoke a protected model; optional only for anonymous models.
@@ -130,6 +131,28 @@ The root composition shares rate state across configuration generations. An unch
 
 The reusable primitive is `nyro_limit::rate::RateLimit`. It accepts counts, a `Duration`, and burst capacity, and returns either admission or a retry delay. It contains no LLM, authentication, HTTP, kernel, or database types; the application owns scope mapping and rejection formatting. Regression: `cargo test -p nyro-limit` and `cargo test -p nyro-llm --test rate_runtime`.
 
+## Token quota
+
+Add an optional `quota` to a public model:
+
+```yaml
+quota:
+  total_tokens: 1000000
+  reserve_tokens: 4096
+```
+
+Both fields are required positive integers; `reserve_tokens` must not exceed `total_tokens`. Explicit `null` and unknown fields are rejected. All callers, workloads and ingress APIs for that alias share one cumulative budget of input plus output tokens. Different aliases have independent budgets. This is process-local accounting with no periodic refill, persistence, pricing or replica coordination.
+
+After authentication, authorization, concurrency and rate admission, Nyro reserves `reserve_tokens` immediately before each available upstream attempt. Retries each need their own reservation. No available backend means no reservation. Admission atomically checks settled usage plus pending reservations. Insufficient credit returns a native `429`: OpenAI APIs use `quota_exceeded`, Anthropic uses `rate_limit_error`, and Gemini uses `RESOURCE_EXHAUSTED`. There is no `Retry-After` or new upstream call, and the concurrency permit is released immediately. A prior rate admission remains charged even when quota rejects the request. A remaining balance below `reserve_tokens` cannot admit another attempt.
+
+On a valid complete response, Nyro replaces the reservation with reported total usage, including explicit zero and usage above the reservation. For JSON this happens before downstream encoding; for SSE it happens at the validated upstream protocol terminal. Usage snapshots are cumulative, not additive, and must not decrease. Input plus output must equal total without overflow; embeddings require input to equal total. Invalid usage fails the response (`502` before streaming, otherwise stream termination). When quota is enabled, OpenAI Chat upstream requests ask for stream usage even when the client has not requested usage output; the client's output preference is preserved.
+
+Before settlement, missing usage, upstream HTTP errors, malformed responses, cancellation, deadlines and dropped/truncated streams charge the greater of the reservation and any valid observed usage. Once settled, later downstream failure or body drop does not change the charge. Only an observed connection-establishment failure releases the entire reservation. Each failed HTTP attempt is charged separately before failover. These conservative fallback charges may overcount actual usage. Conversely, `reserve_tokens` is an operator-selected amount, not a trusted upper bound on provider consumption: actual usage can exceed the configured budget, and the resulting debt blocks later admissions. This is not a hard cap on actual upstream tokens.
+
+The root composition retains consumed and pending ledgers across generations, routing changes, and model removal/re-addition. Changing a rule while its binding is live or its ledger has consumed credit rejects candidate construction. Unused, unowned candidate ledgers can be discarded. Retained ledgers last for the registry's lifetime; process restart resets all balances and is required to change an established rule. The file proxy still requires restart to load configuration edits. Disabling quota stops accounting for new requests; it does not erase an existing ledger.
+
+`nyro_limit::quota::Quota` provides generic atomic reservation, settlement and snapshots without LLM, HTTP, kernel or storage types. `nyro_llm::quota::QuotaRegistry` owns the model mapping and token semantics. Library hosts should reuse `runtime::SharedResources` with `Runtime::with_resources` across generations; `Runtime::new` creates fresh registries and `with_health` shares health only. Regression: `cargo test -p nyro-limit` and `cargo test -p nyro-llm --test quota_runtime`.
+
 ## Native clients and conversion limits
 
 | Client API | Endpoint | Credential |
@@ -182,7 +205,7 @@ References: [OpenAI Responses migration](https://developers.openai.com/api/docs/
 - `GET /healthz` returns `200` while the HTTP process is serving.
 - `GET /readyz` returns `200` while the kernel host accepts new generation leases and `503` once it does not. This source-built proxy has no database or upstream-backend readiness check.
 
-Retries and passive health are opt-in as described above. It does not implement quotas, a control plane, Admin API, WebUI, `nyro serve`, or `nyro tool`. It does not expand environment variables, accept the legacy standalone YAML format, watch or hot-reload the file, or fetch configuration remotely. Restart the process to apply edits.
+Retries and passive health are opt-in as described above. It does not implement persistent/shared quota storage, a control plane, Admin API, WebUI, `nyro serve`, or `nyro tool`. It does not expand environment variables, accept the legacy standalone YAML format, watch or hot-reload the file, or fetch configuration remotely. Restart the process to apply edits.
 
 Contributors can exercise the root process, probes, authentication, Chat, Embedding, SSE, redaction, and graceful termination without a real provider:
 

--- a/docs/standalone/rust-proxy.yaml
+++ b/docs/standalone/rust-proxy.yaml
@@ -42,6 +42,8 @@ llm:
       subjects: [local-client]
     chat-default:
       rate: {requests: 60, period_ms: 60000, burst: 5}
+      # Cumulative per-process budget; reserve is not a hard provider token bound.
+      quota: {total_tokens: 1000000, reserve_tokens: 4096}
       backends:
         - id: primary
           provider: example

--- a/docs/standalone/rust-proxy_CN.md
+++ b/docs/standalone/rust-proxy_CN.md
@@ -44,6 +44,7 @@ Gemini 上游模型名只接受由 ASCII 字母、数字、`-_.` 构成的单段
 - `max_attempts`：正整数，默认 `1`，包含首次上游发送。每个请求最多尝试每个 backend ID 一次。
 - `health`：可选的被动熔断策略，省略时关闭。空对象启用默认值 `failure_threshold: 3` 和 `cooldown_ms: 30000`，两者必须大于零。
 - `rate`：可选的模型请求频率，省略时关闭。见下文“请求频率”。
+- `quota`：可选的模型累计 token 额度，省略时关闭。见下文“Token 额度”。
 - `workloads`：非空且不能重复；所有 backend 都使用 OpenAI Chat Completions 时可包含 `chat`、`embedding` 或两者；Responses／Anthropic／Gemini 只支持 `chat`。每个 backend（包括禁用项）都必须支持模型声明的 workload，无效组合会在启动时被拒绝。
 - `allow_anonymous`：可选，默认 `false`。
 - `subjects`：允许调用受保护模型的客户端凭据 ID；只有匿名模型可以省略。
@@ -130,6 +131,28 @@ rate:
 
 可复用原语为 `nyro_limit::rate::RateLimit`，接收数量、`Duration` 与突发容量，返回准入结果或建议等待时长，不依赖 LLM、认证、HTTP、内核或数据库类型；作用域映射与协议拒绝结果由应用决定。回归测试：`cargo test -p nyro-limit` 和 `cargo test -p nyro-llm --test rate_runtime`。
 
+## Token 额度
+
+在公开模型下添加可选的 `quota`：
+
+```yaml
+quota:
+  total_tokens: 1000000
+  reserve_tokens: 4096
+```
+
+两个字段均为必填正整数，且 `reserve_tokens` 不得超过 `total_tokens`。显式 `null` 和未知字段会被拒绝。同一别名的所有调用方、工作负载和入口 API 共享输入加输出 token 的累计额度，不同别名独立计量。当前仅为进程内记账，不提供定时补充、持久化、金额计费或副本间协调。
+
+认证、授权、并发和 rate 准入之后，Nyro 在每次可用上游尝试发出前预留 `reserve_tokens`，每次重试都需要独立预留。没有可用 backend 时不预留。准入原子检查已结算用量加在途预留；余额不足返回原生协议 `429`：OpenAI API 使用 `quota_exceeded`，Anthropic 使用 `rate_limit_error`，Gemini 使用 `RESOURCE_EXHAUSTED`。不带 `Retry-After`，不发出新的上游请求，并立即释放并发许可。此前 rate 准入已消耗的次数不退还。剩余余额小于 `reserve_tokens` 时无法再准入一次尝试。
+
+完整响应有效时，以报告的总用量替换预留，包括显式零用量和超过预留的用量。JSON 在向下游编码前结算，SSE 在校验上游协议终止信号时结算。用量快照按累计值替换，不逐帧相加，且不能递减；输入加输出必须无溢出地等于总量，Embedding 的输入必须等于总量。无效用量导致响应失败：流开始前返回 `502`，开始后终止流。启用 quota 后，即使客户端未请求输出 usage，OpenAI Chat 上游流请求也会主动请求用量；下游仍保留客户端的输出偏好。
+
+结算前遇到用量缺失、上游 HTTP 错误、无效响应、取消、超时、响应体丢弃或断流，均按预留量与已知有效用量的较大值扣减。已结算后发生的下游失败或响应体丢弃不改变扣减结果。只有实际观察到连接建立失败才全额释放预留；故障转移之前每次失败的 HTTP 尝试独立扣减。这种保守回退可能多计实际用量。另一方面，`reserve_tokens` 是运维配置值，不是可信的上游消耗上界：实际消耗可能超过配置预算，超出部分如实记账并阻止后续准入，当前不承诺真实上游 token 的硬上限。
+
+根组合层在代际、路由变更和模型移除／加回之间保留已消耗及在途账本。规则绑定仍活跃或账本已有消耗时，修改规则会使候选构建失败；无持有者且没有消耗或预留的候选账本可被回收。保留账本持续至注册表销毁，进程重启会清空余额，也是更改已建立规则的方式。文件代理仍需重启才能加载配置修改。关闭 quota 后新请求停止计量，但不会删除已有账本。
+
+`nyro_limit::quota::Quota` 提供通用原子预留、结算和快照，不依赖 LLM、HTTP、内核或存储类型；`nyro_llm::quota::QuotaRegistry` 负责模型映射与 token 语义。库调用方应在代际间复用 `runtime::SharedResources` 并通过 `Runtime::with_resources` 构建运行时；`Runtime::new` 创建全新注册表，`with_health` 仅共享健康状态。回归测试：`cargo test -p nyro-limit` 和 `cargo test -p nyro-llm --test quota_runtime`。
+
 ## 原生客户端与转换限制
 
 | 客户端 API | 端点 | 凭据 |
@@ -182,7 +205,7 @@ SSE 使用 Responses 命名生命周期事件、稳定 item ID、递增序号和
 - HTTP 服务运行期间，`GET /healthz` 返回 `200`。
 - 内核 Host 接受新的代际 lease 时，`GET /readyz` 返回 `200`；停止接受时返回 `503`。这个源码构建代理没有数据库或上游 backend 就绪检查。
 
-重试与被动健康检查需要按上述配置显式开启。尚未实现额度、控制面、Admin API、WebUI、`nyro serve` 或 `nyro tool`。程序不会展开环境变量，不接受旧 Standalone YAML，不监听或热更新文件，也不会远程获取配置；修改后需要重启进程。
+重试与被动健康检查需要按上述配置显式开启。尚未实现额度的持久化／跨进程共享存储、控制面、Admin API、WebUI、`nyro serve` 或 `nyro tool`。程序不会展开环境变量，不接受旧 Standalone YAML，不监听或热更新文件，也不会远程获取配置；修改后需要重启进程。
 
 贡献者可以在不连接真实 Provider 的情况下验证根进程、健康检查、认证、Chat、Embedding、SSE、脱敏和正常退出：
 

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -3,11 +3,7 @@ use std::{sync::Arc, time::Duration};
 use nyro_config::Config;
 use nyro_kernel::{Candidate, Context, Host};
 use nyro_limit::ConcurrencyLimit;
-use nyro_llm::{
-    health::HealthRegistry,
-    rate::RateRegistry,
-    runtime::{Options, Runtime},
-};
+use nyro_llm::runtime::{Options, Runtime, SharedResources};
 use nyro_security::ApiKeys;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
@@ -15,8 +11,7 @@ use tokio_util::sync::CancellationToken;
 pub(crate) struct Resources {
     limit: ConcurrencyLimit,
     capacity: usize,
-    health: Arc<HealthRegistry>,
-    rates: Arc<RateRegistry>,
+    shared: SharedResources,
 }
 
 impl Resources {
@@ -25,8 +20,7 @@ impl Resources {
         Ok(Self {
             limit: ConcurrencyLimit::new(config.limit.concurrency)?,
             capacity: config.limit.concurrency,
-            health: Arc::new(HealthRegistry::default()),
-            rates: Arc::new(RateRegistry::default()),
+            shared: SharedResources::default(),
         })
     }
 
@@ -51,8 +45,7 @@ impl Resources {
                 keys,
                 self.limit.clone(),
                 options,
-                self.health.clone(),
-                self.rates.clone(),
+                self.shared.clone(),
             )?,
             // Reqwest clients have synchronous RAII cleanup; no background component is needed.
             components: vec![],

--- a/src/http.rs
+++ b/src/http.rs
@@ -100,6 +100,89 @@ limit: {{concurrency: 1}}
     }
 
     #[tokio::test]
+    async fn quota_balance_survives_generation_changes_and_model_removal() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let calls = Arc::new(AtomicUsize::new(0));
+        let observed = calls.clone();
+        let upstream = Router::new().route("/v1/chat/completions", post(move || {
+            let calls = observed.clone();
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                axum::Json(json!({"id":"quota","object":"chat.completion","created":1,"model":"private",
+                    "choices":[{"index":0,"message":{"role":"assistant","content":"Hi"},"finish_reason":"stop"}],
+                    "usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}))
+            }
+        }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let mut config = config(&format!("http://{}/v1", listener.local_addr().unwrap()));
+        config.llm.models.get_mut("public").unwrap().quota = Some(nyro_llm::config::QuotaConfig {
+            total_tokens: 8,
+            reserve_tokens: 5,
+        });
+        let task = tokio::spawn(async move { axum::serve(listener, upstream).await.unwrap() });
+        let resources = bootstrap::Resources::new(&config).unwrap();
+        let host = bootstrap::host(&config, &resources).await.unwrap();
+        let tracker = TaskTracker::new();
+        let router = router(host.clone(), tracker.clone());
+        for step in 0..2 {
+            if step == 1 {
+                config.llm.models.get_mut("public").unwrap().backends[0].upstream_model =
+                    "replacement".into();
+                host.activate(
+                    resources.candidate(&config).unwrap(),
+                    Context {
+                        deadline: Instant::now() + Duration::from_secs(1),
+                        cancellation: CancellationToken::new(),
+                    },
+                )
+                .await
+                .unwrap();
+            }
+            let response = router.clone().oneshot(request()).await.unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            to_bytes(response.into_body(), 16384).await.unwrap();
+        }
+        let mut removed = config.clone();
+        let mut other = removed.llm.models.remove("public").unwrap();
+        other.quota = None;
+        removed.llm.models.insert("other".into(), other);
+        for next in [&removed, &config] {
+            host.activate(
+                resources.candidate(next).unwrap(),
+                Context {
+                    deadline: Instant::now() + Duration::from_secs(1),
+                    cancellation: CancellationToken::new(),
+                },
+            )
+            .await
+            .unwrap();
+        }
+        let denied = router.clone().oneshot(request()).await.unwrap();
+        assert_eq!(denied.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert!(!denied.headers().contains_key("retry-after"));
+        let body = to_bytes(denied.into_body(), 16384).await.unwrap();
+        assert_eq!(
+            serde_json::from_slice::<Value>(&body).unwrap()["error"]["code"],
+            "quota_exceeded"
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        config
+            .llm
+            .models
+            .get_mut("public")
+            .unwrap()
+            .quota
+            .as_mut()
+            .unwrap()
+            .total_tokens = 100;
+        assert!(resources.candidate(&config).is_err());
+        host.shutdown().await.unwrap();
+        tracker.close();
+        tracker.wait().await;
+        task.abort();
+    }
+
+    #[tokio::test]
     async fn root_resources_preserve_rate_and_reject_active_policy_changes() {
         use std::sync::atomic::{AtomicUsize, Ordering};
 

--- a/tests/proxy_smoke.py
+++ b/tests/proxy_smoke.py
@@ -94,6 +94,10 @@ def main():
                 "provider": "mock", "upstream_model": "internal",
                 "rate": {"requests": 1, "period_ms": 600000},
                 "workloads": ["chat"], "subjects": ["tester"]}
+            data["llm"]["models"]["public-quota"] = {
+                "provider": "mock", "upstream_model": "internal",
+                "quota": {"total_tokens": 7, "reserve_tokens": 4},
+                "workloads": ["chat", "embedding"], "subjects": ["tester"]}
             config.write_text(json.dumps({**data, "unknown": "secret-marker"}))
             invalid = subprocess.run([binary, "proxy", "--config", config], capture_output=True, timeout=5)
             assert invalid.returncode != 0
@@ -167,6 +171,17 @@ def main():
                 status, body = request("/v1/chat/completions", limited)
                 assert status == 429 and json.loads(body)["error"]["code"] == "rate_limit_exceeded"
                 assert len(Upstream.calls) == 15
+                # Actual usage refunds unused reserve, including SSE usage hidden from the client.
+                for streaming in (False, True):
+                    status, body = request("/v1/chat/completions", {
+                        **chat, "model": "public-quota", "stream": streaming})
+                    assert status == 200
+                    if streaming:
+                        assert body.endswith(b"data: [DONE]\n\n") and b'"usage"' not in body
+                        assert Upstream.calls[-1][2]["stream_options"]["include_usage"] is True
+                status, body = request("/v1/embeddings", {"model": "public-quota", "input": "Hello"})
+                assert status == 429 and json.loads(body)["error"]["code"] == "quota_exceeded"
+                assert len(Upstream.calls) == 17
                 assert all(key == "Bearer upstream-secret" and payload["model"] in {"internal", "temporary-error"}
                            for _, key, payload in Upstream.calls)
                 process.terminate()
@@ -181,7 +196,7 @@ def main():
     finally:
         upstream.shutdown()
         upstream.server_close()
-    print("proxy smoke passed: config, weighted routing, failover, passive health, rate, probes, auth, OpenAI/Anthropic/Gemini Chat/Responses, Embedding, SSE, SIGTERM")
+    print("proxy smoke passed: config, weighted routing, failover, passive health, rate, quota, probes, auth, OpenAI/Anthropic/Gemini Chat/Responses, Embedding, SSE, SIGTERM")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reserve per upstream attempt and settle reported usage. Retain balances across generations and conservatively charge unknown outcomes.

Rust API migration: Runtime::with_resources accepts SharedResources instead of separate health and rate registries. Model literals need quota: None when disabled.