### PR TITLE
fix(llm): preserve tool schema constraints

### DIFF
--- a/crates/nyro-llm/src/codec/anthropic.rs
+++ b/crates/nyro-llm/src/codec/anthropic.rs
@@ -350,7 +350,7 @@ pub fn encode_chat(r: &ChatRequest) -> Result<Value, CodecError> {
             {
                 return Err(bad("invalid tool definition"));
             }
-            if f.get("strict").is_some() {
+            if f.get("strict").and_then(Value::as_bool) == Some(true) {
                 return Err(bad("strict tools unsupported"));
             }
             let mut item = json!({"name":f["name"],"input_schema":f.get("parameters").cloned().unwrap_or(json!({"type":"object"}))});

--- a/crates/nyro-llm/src/codec/gemini.rs
+++ b/crates/nyro-llm/src/codec/gemini.rs
@@ -235,56 +235,112 @@ pub fn decode_chat(value: Value, model: &str, streaming: bool) -> Result<ChatReq
     }
     Ok(r)
 }
+// Convert only schema positions. Defaults are literal data, not nested schemas.
 fn schema_to_json(mut v: Value) -> Result<Value, CodecError> {
     let obj = v
         .as_object_mut()
         .ok_or_else(|| bad("function schema must be an object"))?;
-    for key in obj.keys() {
-        if ![
-            "type",
-            "description",
-            "enum",
-            "properties",
-            "required",
-            "items",
-            "nullable",
-            "format",
-            "minimum",
-            "maximum",
-            "minItems",
-            "maxItems",
-        ]
-        .contains(&key.as_str())
-        {
-            return Err(bad(
-                "unsupported Gemini Schema field; use parametersJsonSchema",
-            ));
+    let nullable = match obj.remove("nullable") {
+        None | Some(Value::Bool(false)) => false,
+        Some(Value::Bool(true)) => true,
+        _ => return Err(bad("invalid nullable")),
+    };
+    // Gemini documents nullable independently of enum/anyOf. Do not guess
+    // whether it overrides their constraints when converting to JSON Schema.
+    if nullable && (obj.contains_key("enum") || obj.contains_key("anyOf")) {
+        return Err(bad(
+            "nullable with enum or anyOf requires parametersJsonSchema",
+        ));
+    }
+    for (key, value) in obj.iter_mut() {
+        match key.as_str() {
+            "type" => {
+                let kind = value
+                    .as_str()
+                    .ok_or_else(|| bad("invalid schema type"))?
+                    .to_ascii_lowercase();
+                if ![
+                    "string", "number", "integer", "boolean", "array", "object", "null",
+                ]
+                .contains(&kind.as_str())
+                {
+                    return Err(bad("unsupported schema type"));
+                }
+                *value = Value::String(kind);
+            }
+            "properties" => {
+                let properties = value
+                    .as_object_mut()
+                    .ok_or_else(|| bad("schema properties must be an object"))?;
+                for property in properties.values_mut() {
+                    *property = schema_to_json(property.take())?;
+                }
+            }
+            "items" => *value = schema_to_json(value.take())?,
+            "anyOf" => {
+                let alternatives = value
+                    .as_array_mut()
+                    .filter(|v| !v.is_empty())
+                    .ok_or_else(|| bad("schema anyOf must be a nonempty array"))?;
+                for alternative in alternatives {
+                    *alternative = schema_to_json(alternative.take())?;
+                }
+            }
+            "minItems" | "maxItems" | "minProperties" | "maxProperties" | "minLength"
+            | "maxLength" => {
+                // Proto JSON encodes int64 as strings; JSON Schema requires numbers.
+                // Accept ordinary nonnegative integers too, without rounding floats.
+                let count = match value {
+                    Value::String(s) if !s.is_empty() && s.bytes().all(|c| c.is_ascii_digit()) => {
+                        s.parse::<i64>().ok()
+                    }
+                    _ => value.as_i64(),
+                }
+                .filter(|n| *n >= 0)
+                .ok_or_else(|| bad("schema count must be a nonnegative int64"))?;
+                *value = Value::from(count);
+            }
+            "required" | "enum" => {
+                if value
+                    .as_array()
+                    .is_none_or(|values| values.iter().any(|v| !v.is_string()))
+                {
+                    return Err(bad("schema required and enum must contain strings"));
+                }
+            }
+            "title" | "description" | "format" | "pattern" => {
+                if !value.is_string() {
+                    return Err(bad("schema annotation must be a string"));
+                }
+            }
+            "minimum" | "maximum" => {
+                if !value.is_number() {
+                    return Err(bad("schema bound must be a number"));
+                }
+            }
+            "default" => {}
+            _ => {
+                return Err(bad(
+                    "unsupported Gemini Schema field; use parametersJsonSchema",
+                ));
+            }
         }
     }
-    if let Some(t) = obj.get_mut("type") {
-        let s = t
-            .as_str()
-            .ok_or_else(|| bad("invalid schema type"))?
-            .to_lowercase();
-        *t = Value::String(s);
+    if obj.contains_key("enum") && obj.get("type").and_then(Value::as_str) != Some("string") {
+        return Err(bad("Gemini Schema enum supports strings only"));
     }
-    if let Some(Value::Object(props)) = obj.get_mut("properties") {
-        for p in props.values_mut() {
-            *p = schema_to_json(p.take())?;
-        }
-    }
-    if let Some(p) = obj.get_mut("items") {
-        *p = schema_to_json(p.take())?;
-    }
-    if let Some(nullable) = obj.remove("nullable") {
-        if nullable == true {
-            let t = obj
-                .remove("type")
-                .ok_or_else(|| bad("nullable schema requires type"))?;
-            obj.insert("type".into(), serde_json::json!([t, "null"]));
-        } else if nullable != false {
-            return Err(bad("invalid nullable"));
-        }
+    if nullable {
+        let kind = obj
+            .remove("type")
+            .ok_or_else(|| bad("nullable schema requires type"))?;
+        obj.insert(
+            "type".into(),
+            if kind == "null" {
+                kind
+            } else {
+                serde_json::json!([kind, "null"])
+            },
+        );
     }
     Ok(v)
 }
@@ -437,7 +493,7 @@ pub fn encode_chat(r: &ChatRequest) -> Result<Value, CodecError> {
         .map(|ts| {
             ts.iter()
                 .map(|o::Tool::Function { function: f }| {
-                    if f.strict.is_some() {
+                    if f.strict == Some(true) {
                         return Err(bad("strict tools unsupported"));
                     }
                     Ok(w::FunctionDeclaration {

--- a/crates/nyro-llm/src/codec/openai.rs
+++ b/crates/nyro-llm/src/codec/openai.rs
@@ -63,6 +63,14 @@ fn validate_chat(request: &ChatRequest) -> Result<(), CodecError> {
     if request.messages.is_empty() {
         return Err(invalid("messages must be nonempty"));
     }
+    for tool in request.openai.tools.iter().flatten() {
+        let chat::Tool::Function { function } = tool;
+        if function.name.trim().is_empty()
+            || function.parameters.as_ref().is_some_and(|v| !v.is_object())
+        {
+            return Err(invalid("function requires a name and object parameters"));
+        }
+    }
     for message in &request.messages {
         if message.tool_error && message.role != Role::Tool {
             return Err(invalid("tool_error requires a tool result"));

--- a/crates/nyro-llm/tests/responses_runtime.rs
+++ b/crates/nyro-llm/tests/responses_runtime.rs
@@ -1403,3 +1403,152 @@ async fn gemini_result_objects_keep_business_data_without_inventing_error_status
         assert_eq!(serde_json::from_str::<Value>(text).unwrap(), object);
     }
 }
+
+fn schema_pointer(format: &str) -> &'static str {
+    match format {
+        "openai" => "/tools/0/function/parameters",
+        "responses" => "/tools/0/parameters",
+        "anthropic" => "/tools/0/input_schema",
+        _ => "/tools/0/functionDeclarations/0/parametersJsonSchema",
+    }
+}
+
+async fn schema_request(
+    format: &str,
+    streaming: bool,
+    schema: &Value,
+    strict: bool,
+    native: bool,
+) -> Request<Body> {
+    let (parts, body) = tool_request(format, streaming).await.into_parts();
+    let mut value: Value = serde_json::from_slice(&to_bytes(body, 65536).await.unwrap()).unwrap();
+    *value.pointer_mut(schema_pointer(format)).unwrap() = schema.clone();
+    match format {
+        "openai" => value["tools"][0]["function"]["strict"] = json!(strict),
+        "responses" => value["tools"][0]["strict"] = json!(strict),
+        "gemini" if native => {
+            let f = &mut value["tools"][0]["functionDeclarations"][0];
+            f.as_object_mut().unwrap().remove("parametersJsonSchema");
+            f["parameters"] = schema.clone();
+        }
+        _ => {}
+    }
+    Request::from_parts(parts, Body::from(value.to_string()))
+}
+
+#[tokio::test]
+async fn function_schemas_preserve_constraints_and_strict_backend_eligibility() {
+    let schema = json!({"type":"object","$defs":{"query":{"type":"string","pattern":"^[a-z]+$"}},
+        "properties":{"query":{"$ref":"#/$defs/query"}},"required":["query"],"additionalProperties":false,
+        "default":{"type":"literal","nullable":true}});
+    for target in FORMATS {
+        let fixture = upstream(target, "normal").await;
+        let limit = ConcurrencyLimit::new(1).unwrap();
+        let gateway = runtime(&fixture, target, limit.clone(), Options::default());
+        for source in FORMATS {
+            for strict in [false, true] {
+                if strict && !matches!(source, "openai" | "responses") {
+                    continue;
+                }
+                for streaming in [false, true] {
+                    let before = fixture.calls.lock().unwrap().len();
+                    let response = gateway
+                        .handle(
+                            schema_request(source, streaming, &schema, strict, false).await,
+                            CancellationToken::new(),
+                        )
+                        .await;
+                    let allowed = !strict || matches!(target, "openai" | "responses");
+                    assert_eq!(
+                        response.status(),
+                        if allowed {
+                            StatusCode::OK
+                        } else {
+                            StatusCode::BAD_REQUEST
+                        },
+                        "{source} -> {target}, strict={strict}"
+                    );
+                    let body = to_bytes(response.into_body(), 65536).await.unwrap();
+                    assert_eq!(limit.available(), 1);
+                    let calls = fixture.calls.lock().unwrap();
+                    assert_eq!(calls.len(), before + usize::from(allowed));
+                    if !allowed {
+                        continue;
+                    }
+                    let result = if streaming {
+                        stream_snapshot(source, &body)
+                    } else {
+                        snapshot(source, &serde_json::from_slice(&body).unwrap())
+                    };
+                    assert_eq!(result["text"], "Hello");
+                    let sent = &calls.last().unwrap()["body"];
+                    assert_eq!(sent.pointer(schema_pointer(target)).unwrap(), &schema);
+                    match target {
+                        "responses" => assert_eq!(sent["tools"][0]["strict"], strict),
+                        "openai" if strict => {
+                            assert_eq!(sent["tools"][0]["function"]["strict"], true)
+                        }
+                        "anthropic" => assert!(sent["tools"][0].get("strict").is_none()),
+                        "gemini" => assert!(
+                            sent["tools"][0]["functionDeclarations"][0]
+                                .get("strict")
+                                .is_none()
+                        ),
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn gemini_schema_normalization_and_rejections_precede_network_dispatch() {
+    let schema = json!({"type":"OBJECT","properties":{"query":{"type":"STRING","minLength":"2","nullable":true},"items":{"type":"ARRAY","minItems":"1","items":{"type":"INTEGER","minimum":0}}},"required":["query"]});
+    let expected = json!({"type":"object","properties":{"query":{"type":["string","null"],"minLength":2},"items":{"type":"array","minItems":1,"items":{"type":"integer","minimum":0}}},"required":["query"]});
+    for target in FORMATS {
+        let fixture = upstream(target, "normal").await;
+        let limit = ConcurrencyLimit::new(1).unwrap();
+        let gateway = runtime(&fixture, target, limit.clone(), Options::default());
+        for streaming in [false, true] {
+            let response = gateway
+                .handle(
+                    schema_request("gemini", streaming, &schema, false, true).await,
+                    CancellationToken::new(),
+                )
+                .await;
+            assert_eq!(response.status(), StatusCode::OK, "{target}");
+            let body = to_bytes(response.into_body(), 65536).await.unwrap();
+            let result = if streaming {
+                stream_snapshot("gemini", &body)
+            } else {
+                snapshot("gemini", &serde_json::from_slice(&body).unwrap())
+            };
+            assert_eq!(result["text"], "Hello");
+            assert_eq!(
+                fixture.calls.lock().unwrap().last().unwrap()["body"]
+                    .pointer(schema_pointer(target))
+                    .unwrap(),
+                &expected
+            );
+            assert_eq!(limit.available(), 1);
+        }
+        let before = fixture.calls.lock().unwrap().len();
+        for bad in [
+            json!({"type":"OBJECT","propertyOrdering":["query"]}),
+            json!({"type":"OBJECT","properties":{"x":{"type":"STRING","nullable":true,"enum":["x"]}}}),
+            json!({"type":"OBJECT","properties":{"x":{"type":"ARRAY","minItems":"invalid"}}}),
+        ] {
+            let response = gateway
+                .handle(
+                    schema_request("gemini", false, &bad, false, true).await,
+                    CancellationToken::new(),
+                )
+                .await;
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            to_bytes(response.into_body(), 65536).await.unwrap();
+            assert_eq!(fixture.calls.lock().unwrap().len(), before);
+            assert_eq!(limit.available(), 1);
+        }
+    }
+}

--- a/crates/nyro-llm/tests/tool_schema_codec.rs
+++ b/crates/nyro-llm/tests/tool_schema_codec.rs
@@ -1,0 +1,139 @@
+//! Schema expectations use literal wire forms, never Nyro's normalization helpers.
+use nyro_llm::{
+    codec::{anthropic, gemini, openai},
+    ir::ChatRequest,
+};
+use serde_json::{Value, json};
+
+fn chat(schema: Value, strict: bool) -> Value {
+    json!({"model":"m","messages":[{"role":"user","content":"hello"}],"max_tokens":64,
+        "tools":[{"type":"function","function":{"name":"lookup","parameters":schema,"strict":strict}}]})
+}
+fn native(schema: Value) -> Value {
+    json!({"contents":[{"parts":[{"text":"hello"}]}],"generationConfig":{"maxOutputTokens":64},
+        "tools":[{"functionDeclarations":[{"name":"lookup","parameters":schema}]}]})
+}
+fn schemas(r: &ChatRequest) -> Vec<Value> {
+    vec![openai::encode_chat(r).unwrap()["tools"][0]["function"]["parameters"].clone(),
+        openai::responses::encode_chat(r).unwrap()["tools"][0]["parameters"].clone(),
+        anthropic::encode_chat(r).unwrap()["tools"][0]["input_schema"].clone(),
+        gemini::encode_chat(r).unwrap()["tools"][0]["functionDeclarations"][0]["parametersJsonSchema"].clone()]
+}
+#[test]
+fn explicit_non_strict_tools_are_portable_but_strict_guarantees_are_not_dropped() {
+    for strict in [false, true] {
+        let r = openai::decode_chat(chat(
+            json!({"type":"object","properties":{},"additionalProperties":false}),
+            strict,
+        ))
+        .unwrap();
+        assert_eq!(
+            openai::encode_chat(&r).unwrap()["tools"][0]["function"]["strict"],
+            strict
+        );
+        assert_eq!(
+            openai::responses::encode_chat(&r).unwrap()["tools"][0]["strict"],
+            strict
+        );
+        assert_eq!(anthropic::encode_chat(&r).is_ok(), !strict);
+        assert_eq!(gemini::encode_chat(&r).is_ok(), !strict);
+    }
+}
+#[test]
+fn function_envelopes_are_checked_at_decode_and_public_encode_boundaries() {
+    let valid = chat(json!({"type":"object"}), false);
+    for bad_schema in [json!(true), json!([]), json!("object"), json!(3)] {
+        let mut value = valid.clone();
+        value["tools"][0]["function"]["parameters"] = bad_schema.clone();
+        assert!(openai::decode_chat(value).is_err(), "{bad_schema}");
+        let mut r = openai::decode_chat(valid.clone()).unwrap();
+        let nyro_protocol::openai::chat::Tool::Function { function } =
+            &mut r.openai.tools.as_mut().unwrap()[0];
+        function.parameters = Some(bad_schema);
+        assert!(openai::encode_chat(&r).is_err());
+        assert!(openai::responses::encode_chat(&r).is_err());
+        assert!(anthropic::encode_chat(&r).is_err());
+        assert!(gemini::encode_chat(&r).is_err());
+    }
+    for name in ["", "   "] {
+        let mut value = valid.clone();
+        value["tools"][0]["function"]["name"] = json!(name);
+        assert!(openai::decode_chat(value).is_err());
+    }
+}
+#[test]
+fn json_schema_references_constraints_and_literal_data_are_not_rewritten() {
+    let schema = json!({"type":"object","$defs":{"value":{"type":"string","pattern":"^[A-Z]+$"}},
+        "properties":{"item":{"$ref":"#/$defs/value"},"optional":{"anyOf":[{"type":"null"},{"type":"integer","minimum":0}]}},
+        "required":["item"],"additionalProperties":false,
+        "default":{"type":"BUSINESS_DATA","nullable":true,"$ref":"literal"}});
+    let mut r = openai::decode_chat(chat(schema.clone(), false)).unwrap();
+    // Existing non-strict IR form also exercises preservation independently of false support.
+    let nyro_protocol::openai::chat::Tool::Function { function } =
+        &mut r.openai.tools.as_mut().unwrap()[0];
+    function.strict = None;
+    for actual in schemas(&r) {
+        assert_eq!(actual, schema);
+    }
+    let mut v = native(json!({}));
+    let f = &mut v["tools"][0]["functionDeclarations"][0];
+    f.as_object_mut().unwrap().remove("parameters");
+    f["parametersJsonSchema"] = schema.clone();
+    for actual in schemas(&gemini::decode_chat(v, "m", false).unwrap()) {
+        assert_eq!(actual, schema);
+    }
+}
+#[test]
+fn gemini_schema_converts_nested_constraints_without_touching_default_data() {
+    let native_schema = json!({"type":"OBJECT","title":"Query","minProperties":"1","maxProperties":4,
+        "properties":{
+            "items":{"type":"ARRAY","minItems":"1","maxItems":3,"items":{"type":"STRING","minLength":"2","maxLength":"8","pattern":"^[A-Z]+$"}},
+            "choice":{"type":"STRING","format":"enum","enum":["A","B"]},
+            "value":{"anyOf":[{"type":"INTEGER","minimum":0,"maximum":7},{"type":"STRING","nullable":true}]},
+            "data":{"type":"OBJECT","default":{"type":"STRING","nullable":true,"minItems":"business"}}
+        },"required":["items"]});
+    let expected = json!({"type":"object","title":"Query","minProperties":1,"maxProperties":4,
+        "properties":{
+            "items":{"type":"array","minItems":1,"maxItems":3,"items":{"type":"string","minLength":2,"maxLength":8,"pattern":"^[A-Z]+$"}},
+            "choice":{"type":"string","format":"enum","enum":["A","B"]},
+            "value":{"anyOf":[{"type":"integer","minimum":0,"maximum":7},{"type":["string","null"]}]},
+            "data":{"type":"object","default":{"type":"STRING","nullable":true,"minItems":"business"}}
+        },"required":["items"]});
+    for actual in schemas(&gemini::decode_chat(native(native_schema), "m", false).unwrap()) {
+        assert_eq!(actual, expected);
+    }
+}
+#[test]
+fn gemini_schema_rejects_malformed_or_unmapped_constraints_instead_of_weakening_them() {
+    for field in [
+        json!({"type":"UNRECOGNIZED"}),
+        json!({"type":3}),
+        json!({"type":"OBJECT","properties":[]}),
+        json!({"type":"OBJECT","required":"x"}),
+        json!({"type":"STRING","enum":[1]}),
+        json!({"type":"INTEGER","enum":["1"]}),
+        json!({"type":"STRING","nullable":true,"enum":["A"]}),
+        json!({"type":"STRING","nullable":true,"anyOf":[{"type":"STRING"}]}),
+        json!({"type":"STRING","nullable":"true"}),
+        json!({"type":"ARRAY","minItems":"1.5"}),
+        json!({"type":"ARRAY","maxItems":-1}),
+        json!({"type":"ARRAY","maxItems":"9223372036854775808"}),
+        json!({"type":"STRING","minLength":null}),
+        json!({"type":"NUMBER","minimum":"1"}),
+        json!({"type":"STRING","anyOf":[]}),
+        json!({"type":"STRING","anyOf":[false]}),
+        json!({"type":"OBJECT","propertyOrdering":["x"]}),
+        json!({"type":"OBJECT","additionalProperties":false}),
+        json!({"type":"OBJECT","$ref":"#/defs/x"}),
+    ] {
+        assert!(
+            gemini::decode_chat(
+                native(json!({"type":"OBJECT","properties":{"x":field.clone()}})),
+                "m",
+                false
+            )
+            .is_err(),
+            "accepted {field}"
+        );
+    }
+}

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -496,7 +496,7 @@ Chat 流使用自己的事件类型，不要求所有交互实现流接口。当
 
 ### 8.3 对外复用范围
 
-`nyro-protocol` 独立提供 OpenAI、Anthropic、Gemini 基础协议格式，社区项目解析这些协议时不需要构建 Nyro runtime、内核或数据库。IR 与跨协议转换暂留 `nyro-llm`，本次不承诺一个独立的 IR/转换 SDK。Responses 是 OpenAI 族内的一种 API，与 Chat Completions 共享 Chat workload；上游通过 `kind: openai` 加 `api: responses` 选择，不新增 Provider 族或 crate。现有 Chat IR 支持无状态文本、拒绝、客户端函数调用／结果及用量，不能完整承载 Responses 的服务端会话、item 引用、内置工具或 reasoning items，因此严格转换路径明确拒绝这些语义。匹配的 Responses 原生模式可保留 reasoning 历史和媒体等 JSON 扩展，但仍不支持托管会话、item 引用或内置工具；这些字段不进入公共 IR。具体转换与流状态边界见实验性代理指南。
+`nyro-protocol` 独立提供 OpenAI、Anthropic、Gemini 基础协议格式，社区项目解析这些协议时不需要构建 Nyro runtime、内核或数据库。IR 与跨协议转换暂留 `nyro-llm`，本次不承诺一个独立的 IR/转换 SDK。Responses 是 OpenAI 族内的一种 API，与 Chat Completions 共享 Chat workload；上游通过 `kind: openai` 加 `api: responses` 选择，不新增 Provider 族或 crate。现有 Chat IR 支持无状态文本、拒绝、客户端函数调用／结果及用量，不能完整承载 Responses 的服务端会话、item 引用、内置工具或 reasoning items，因此严格转换路径明确拒绝这些语义。匹配的 Responses 原生模式可保留 reasoning 历史和媒体等 JSON 扩展，但仍不支持托管会话、item 引用或内置工具；这些字段不进入公共 IR。函数参数 Schema 仍由 codec 处理：JSON Schema 对象保留原字段，Gemini 原生 Schema 只转换明确支持的方言子集，无法保留的约束拒绝。当前不引入通用 Schema 校验框架，也不在内核或执行链中展开引用、裁剪约束或验证工具执行参数。具体转换与流状态边界见实验性代理指南。
 
 ## 9. 共享安全、限制与观测能力
 
@@ -558,7 +558,7 @@ schema 的所有权不因共用数据库而合并。修改实际迁移源时仍�
 | 阶段 | 当前进度 | 差异跟踪 |
 |---|---|---|
 | 内核、代际、文件配置 | 基础机制已落地；SIGHUP 重载已有回归 | 后续能力必须保持生命周期与清理约束 |
-| LLM 数据面 | 主要执行链已落地；模型发现 G01 已补齐，G02 已支持显式开启 OpenAI Chat／无状态 Responses／Anthropic Messages／单候选 Gemini 原生 JSON/SSE 保真；G04 已补充 Anthropic／Gemini 完整工具结果批次、显式错误状态边界、文本结果块与 Gemini ID／顺序校验；Schema 兼容仍待处理；整体兼容对齐未完成 | G02–G09 |
+| LLM 数据面 | 主要执行链已落地；模型发现 G01 已补齐，G02 已支持显式开启 OpenAI Chat／无状态 Responses／Anthropic Messages／单候选 Gemini 原生 JSON/SSE 保真；G04 已补充 Anthropic／Gemini 完整工具结果批次、显式错误状态边界、文本结果块与 Gemini ID／顺序校验；函数 Schema 已补充 JSON 约束保留、Gemini 方言转换与 strict 目标边界；整体兼容对齐未完成 | G02–G09 |
 | 控制面、存储、管理与持久化观测 | 尚未接入新架构 | G10–G12 |
 | 工具、部署和旧入口切换 | 尚未完成切换验收 | G11、G13 |
 

--- a/docs/design/rust-migration-gaps.md
+++ b/docs/design/rust-migration-gaps.md
@@ -1,6 +1,6 @@
 # Rust 迁移差异审计
 
-审计基线：`d943c174`（2026-09-09，含 PR #323）。后续关闭状态：G01 已由 PR #324 补齐；G02 的 OpenAI Chat／Anthropic Messages／Gemini／无状态 Responses 原生增量已由 PR #325–#328 合并，G04 的 Anthropic 并行结果增量已由 PR #329 合并，本轮在 `9bea9960` 上推进其余工具历史／结果语义，其余差异继续跟踪。本文核对仓库实现和测试，不代表真实厂商或 SDK 兼容认证。[架构文档](architecture.md)仍是目标设计，[实验性代理指南](../standalone/rust-proxy_CN.md)说明当前支持范围。
+审计基线：`d943c174`（2026-09-09，含 PR #323）。后续关闭状态：G01 已由 PR #324 补齐；G02 的 OpenAI Chat／Anthropic Messages／Gemini／无状态 Responses 原生增量已由 PR #325–#328 合并，G04 的工具历史／结果增量已由 PR #329–#330 合并，本轮在 `ee774419` 上推进函数 Schema 兼容与拒绝边界，其余差异继续跟踪。本文核对仓库实现和测试，不代表真实厂商或 SDK 兼容认证。[架构文档](architecture.md)仍是目标设计，[实验性代理指南](../standalone/rust-proxy_CN.md)说明当前支持范围。
 
 **新文件配置 LLM 数据面已具备主要执行和生命周期机制，尚不能替换已发布 Server。** 同名能力不等于契约已迁移：模型 token bucket 不等于 API Key 请求窗口；存在 Responses 端点也不等于兼容 Codex 账号通道。
 
@@ -29,7 +29,7 @@
 | G01 模型发现 | 已落地 | [旧模型列表](../../crates/nyro-core/src/proxy/handler.rs)的发现能力已由[新运行时](../../crates/nyro-llm/src/runtime.rs)承接；[模型列表测试](../../crates/nyro-llm/tests/models_runtime.rs)与[重载进程测试](../../tests/proxy_reload_smoke.py)覆盖过滤及代际变化。 | 按授权返回稳定排序的公开别名；匿名／绑定／无效／歧义凭证、空列表、成功／失败重载、密钥轮换和预算隔离已覆盖。无效密钥明确拒绝，不沿用旧公开列表回退；密钥到期仍由 G06 跟踪。 |
 | G02 同协议保真 | 部分 | [旧调度器](../../crates/nyro-core/src/proxy/dispatcher/mod.rs)按条件选择 Native 模式；[请求构建](../../crates/nyro-core/src/provider/common/pipeline.rs)和[非流式响应](../../crates/nyro-core/src/proxy/dispatcher/non_stream.rs)可跳过 IR 往返。[新运行时](../../crates/nyro-llm/src/runtime/native.rs)通过 Provider `native_chat: true` 保留匹配的 OpenAI Chat／无状态 Responses／Anthropic Messages／单候选 Gemini 请求、JSON 响应及 SSE 扩展；默认仍严格转换。 | OpenAI Chat／无状态 Responses／Anthropic Messages 和单候选 Gemini 的别名路由、usage、凭证隔离、重试兼容筛选、有界解析及流终态已覆盖；多候选／独立工具提示词计量和完整客户端仍待验收；Responses 已补无状态原生 mock 验证。Gemini 原生保留上游 modelVersion。只保留 JSON 字段，不承诺字节或任意 Header 透传；跨协议原始请求仍须通过来源严格 codec。 |
 | G03 推理、缓存与媒体语义 | 部分 | [旧转换测试](../../crates/nyro-core/tests/protocol_conversion.rs)覆盖 thinking／签名回放、`reasoning_content`、think-tag 归一化和 Gemini `fileData`。[新版限制](../standalone/rust-proxy_CN.md)的严格转换路径仍拒绝未支持的 Chat 内容块、缓存扩展和 Responses reasoning items；OpenAI Chat／Responses／Anthropic Messages／Gemini 原生模式只保留这些 JSON 字段，不新增跨协议语义映射。 | 为保留客户端建立字段／场景矩阵，保留可表达语义，明确拒绝不可表达的跨协议转换。OpenAI Chat 已有图片／音频类型字段，不能笼统说所有多模态都缺失；新增独立 Image/Audio/Video 操作另算范围。 |
-| G04 工具历史与 Schema 处理 | 部分／待取舍 | 旧转换测试包含合成调用、重复 ID 修复、丢弃中间文本／孤立调用、Gemini Schema 裁剪。新 [Anthropic](../../crates/nyro-llm/tests/anthropic_codec.rs)／[Gemini](../../crates/nyro-llm/tests/gemini_codec.rs) encoder 保留完整结果批次及后续文本，拒绝缺失／重复／交错批次；Anthropic 显式错误、空结果、[Responses](../../crates/nyro-llm/tests/responses_codec.rs) 文本块数组及 Gemini ID／顺序已补充。多块结果到 Gemini、跨协议错误标志映射和媒体结果明确拒绝。Schema 兼容待下一增量。 | 回放并行调用、交错文本、工具结果和 Schema，保留合法客户端历史；不自动迁移虚构调用或丢内容的处理。区分有意拒绝和兼容回退。 |
+| G04 工具历史与 Schema 处理 | 部分／待取舍 | 旧转换测试包含合成调用、重复 ID 修复、丢弃中间文本／孤立调用、Gemini Schema 裁剪。新 [Anthropic](../../crates/nyro-llm/tests/anthropic_codec.rs)／[Gemini](../../crates/nyro-llm/tests/gemini_codec.rs) encoder 保留完整结果批次及后续文本，拒绝缺失／重复／交错批次；Anthropic 显式错误、空结果、[Responses](../../crates/nyro-llm/tests/responses_codec.rs) 文本块数组及 Gemini ID／顺序已补充。多块结果到 Gemini、跨协议错误标志映射和媒体结果明确拒绝。[Schema 回归](../../crates/nyro-llm/tests/tool_schema_codec.rs)已覆盖 JSON Schema 对象保留、Gemini 计数／类型／嵌套方言转换及 strict 目标筛选；不裁剪引用或约束。完整客户端／厂商验收仍待后续。 | 回放并行调用、交错文本、工具结果和 Schema，保留合法客户端历史；不自动迁移虚构调用或丢内容的处理。区分有意拒绝和兼容回退。 |
 | G05 Provider 通道与凭证 | 部分 | 旧版有[厂商适配](../../crates/nyro-core/src/provider/mod.rs)、[账号认证 driver](../../crates/nyro-core/src/auth/drivers/mod.rs)和 Vertex 服务账号支持。新 Provider 配置只有协议 kind、可选 OpenAI API、URL 和可选静态 API Key。 | 迁移必要端点、Header 和凭证行为，不向 driver 传递 Gateway 或数据库实体。账号授权、刷新、持久化归控制面；driver 消费已解析凭证。详见下方清单。 |
 | G06 API Key 生命周期 | 部分 | [旧授权](../../crates/nyro-core/src/proxy/dispatcher/auth.rs)检查启用状态、过期时间和模型绑定。新 `ApiKey` 只有 `id`、`secret`；可以重载移除密钥，但没有到期自动失效。 | 对新准入执行到期检查；发布配置保留绑定及禁用语义，验证时间边界和重载；明确已准入请求保持原代际。模型发现与调用授权保持一致。 |
 | G07 限制作用域与持久化 | 部分 | 旧授权按 API Key 查询 Minute/Day 窗口的请求／token 数（`rpm/rpd/tpm/tpd`）。新 rate 是模型级 token bucket；quota 是模型级、累计、进程内 token 额度。 | 明确主体／模型作用域、窗口／重置、尝试与完成的计量、重启行为；测试同一密钥跨模型、多密钥共享模型。显式迁移策略含义，不静默将 RPM 转成不同桶规则或将 TPM 转成累计额度；也不复制旧日志查询准入的竞争问题。 |
@@ -76,7 +76,7 @@
 | 4 | G10–G12：最小 `nyro serve`，先 SQLite 和一条管理到发布路径，再补 Postgres 等价与其余管理能力。 | 持久化 → 校验 → 发布 → 新请求使用快照；失败保留活动代际；重启／数据兼容；WebUI/API 与观测一致。可与兼容工作并行推进，单独完成不代表可发布替换。 |
 | 5 | G11/G13：部署、工具、发布切换。 | 文件／控制面等价，保留 CLI、录制客户端矩阵、支持平台构建、迁移／恢复说明全部过关后移除旧入口。 |
 
-步骤 1 已完成；步骤 2 已完成 16 份录制样本分类、OpenAI Chat／Anthropic Messages 原生增量及单候选 Gemini mock 验证，无状态 Responses 原生 mock 验证也已完成；PR #329 补充四种入口到 Anthropic 的完整并行工具结果历史转换，本轮补充工具错误、空／分块文本结果及 Gemini ID／批次语义；接下来核对 Schema 兼容，跨协议推理及真实会话仍继续跟踪。原生保真和密钥限制语义仍是发布阻塞项；后续每一步可能需要多份聚焦 PR。
+步骤 1 已完成；步骤 2 已完成 16 份录制样本分类、OpenAI Chat／Anthropic Messages 原生增量及单候选 Gemini mock 验证，无状态 Responses 原生 mock 验证也已完成；PR #329 补充四种入口到 Anthropic 的完整并行工具结果历史转换，PR #330 补充工具错误、空／分块文本结果及 Gemini ID／批次语义，本轮补充函数 Schema 保留、转换和拒绝边界；跨协议推理及真实会话仍继续跟踪。原生保真和密钥限制语义仍是发布阻塞项；后续每一步可能需要多份聚焦 PR。
 
 复用[现有录制 fixture](../../tests/e2e/fixtures)和[旧回放矩阵](../../tests/e2e/proxy/test_protocol_matrix.py)作为输入，不能把它们当作新代理已通过的证据。旧 harness 依赖旧配置／工具流程，部分断言仅检查文本锚点／字段名；新断言必须核对有效内容顺序、工具 ID／参数、用量、凭证隔离和终态。端到端认证需记录客户端版本，本地 mock 不代表当前 SDK／厂商兼容。
 
@@ -267,4 +267,34 @@ python3 tests/proxy_reload_smoke.py
 
 286 项 Rust 测试通过（相比上一增量新增 17 项，另将 `nyro-protocol` 的既有 3 项纳入本轮命令），Clippy、非桌面 workspace 检查、构建和五组进程回归通过。16 份录制样本的原生精确回放、默认严格／显式 false 分类均通过；格式、diff 和 92 个文档相对链接检查通过。`docs/superpowers/` 继续保持忽略，不纳入 Git。
 
-G04 仍为部分完成：下一开发项为 Schema 兼容与拒绝边界，媒体结果和无法保留的交错顺序继续明确拒绝。G03 跨协议推理／签名及 G02 真实厂商／完整客户端会话仍未完成；本轮未使用真实厂商密钥。验证结果在本节记录，整体迁移完成后删除本文，不归档。
+PR #330 结束时，G04 仍为部分完成：下一开发项为 Schema 兼容与拒绝边界，后续状态见第 14 节；媒体结果和无法保留的交错顺序继续明确拒绝。G03 跨协议推理／签名及 G02 真实厂商／完整客户端会话仍未完成；本轮未使用真实厂商密钥。验证结果在本节记录，整体迁移完成后删除本文，不归档。
+
+## 14. G04 函数 Schema 兼容增量
+
+核对[旧 Gemini Schema 裁剪](../../crates/nyro-core/src/protocol/codec/google/gemini/encoder.rs)后，本轮保留 JSON Schema 对象和引用，不迁移删除 `$schema`、`additionalProperties`、`$ref`、`definitions`／`$defs` 的行为。原生 Gemini `parameters` 方言的计数字段是 int64 字符串，原先直接送入 JSON Schema 会留下错误字段类型；该问题由明确转换修复，不通过裁剪消除约束。
+
+- OpenAI Chat、Responses、Anthropic 与 Gemini `parametersJsonSchema` 路径保留 JSON Schema 对象；共享校验检查非空白函数名和参数对象形状，也覆盖直接调用公共 encoder 的 IR 请求。不添加通用 JSON Schema 校验器、引用解析器或工具参数执行校验。
+- OpenAI Chat 显式 `strict:false` 可发送到 Anthropic／Gemini；`strict:true` 仍只在当前可保留它的 OpenAI Chat／Responses 目标之间转换。Responses 入口显式 strict 要求不变，出站始终设置 strict，不因默认值变化擅自加强约束。
+- Gemini 原生 Schema 在 properties/items/anyOf 位置递归转换，保留字面 default 数据，转换已知类型及非负 int64 计数，校验受支持字段的形状。拒绝未知字段、错误类型，以及 nullable 与 enum/anyOf 的含糊组合；propertyOrdering、example、原生方言的引用和 additionalProperties 不被静默删除，JSON Schema 可改用 parametersJsonSchema。详细支持表见[代理指南](../standalone/rust-proxy_CN.md)。
+
+新增 5 项 [codec 测试](../../crates/nyro-llm/tests/tool_schema_codec.rs)：4 项先复现缺失校验、strict:false 误拒绝和 Schema 转换问题，再通过修复；另一项固定已有 JSON Schema／引用／字面数据保留契约。新增 2 项[运行时矩阵](../../crates/nyro-llm/tests/responses_runtime.rs)覆盖 48 组 JSON／SSE Schema／strict 组合、8 组 Gemini 方言转换及 12 组发送前拒绝，并核对实际上游 Schema、并发许可释放和成功响应。
+
+独立代码审查未发现阻塞问题。实际执行：
+
+```sh
+cargo test -p nyro-llm --test tool_schema_codec --test openai_codec --test anthropic_codec --test gemini_codec --test responses_codec --offline
+cargo test -p nyro-llm --test responses_runtime --offline
+cargo test -p nyro-protocol -p nyro-llm -p nyro-config -p nyro --offline
+cargo clippy -p nyro-protocol -p nyro-llm -p nyro-config -p nyro --all-targets --offline -- -D warnings
+cargo check --workspace --exclude nyro-desktop --offline
+cargo build -p nyro --offline
+python3 tests/proxy_native_replay.py
+python3 tests/proxy_gemini_native_smoke.py
+python3 tests/proxy_responses_native_smoke.py
+python3 tests/proxy_smoke.py
+python3 tests/proxy_reload_smoke.py
+```
+
+293 项 Rust 测试（本轮新增 7 项）、Clippy、非桌面 workspace 检查、构建和五组进程回归通过。16 份录制样本的原生精确回放及默认严格／显式 false 分类通过；格式、diff 和 97 个文档相对链接检查通过。`docs/superpowers/` 继续忽略，不进入 Git。
+
+G04 的当前文本／客户端函数子集已具备历史和 Schema 回归证据；仍不据此宣称全部厂商／客户端兼容完成。媒体工具结果、不可保留的顺序、含糊 Schema 映射继续明确拒绝，完整客户端验收与 G02–G03 协同推进。没有使用真实厂商密钥，没有新增 crate、依赖或内核职责。

--- a/docs/standalone/rust-proxy.md
+++ b/docs/standalone/rust-proxy.md
@@ -243,7 +243,27 @@ This covers OpenAI Chat, stateless Responses, Anthropic Messages and Gemini gene
 | Gemini missing result ID | Resolved only when the pending function name identifies exactly one call. Explicit IDs must also match the function name; generated missing call IDs avoid explicit IDs anywhere in the history. |
 | Gemini text mixed with function results | Decoded in order into separate IR messages. Anthropic/Gemini targets reject text interrupting an unfinished result batch; compatible OpenAI Chat/Responses targets retain the order. |
 
-No calls are synthesized or content discarded to repair a history. Cross-protocol thinking/signature mapping, media tool results and Schema rewriting remain outside this increment. References: [Anthropic tool results](https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls), [Gemini FunctionResponse](https://ai.google.dev/api/generate-content). Local regressions: `cargo test -p nyro-llm --test anthropic_codec --test gemini_codec --test responses_codec --test responses_runtime --test protocol_matrix`.
+No calls are synthesized or content discarded to repair a history. Cross-protocol thinking/signature mapping and media tool results remain unsupported. Function Schema conversion is described below. References: [Anthropic tool results](https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls), [Gemini FunctionResponse](https://ai.google.dev/api/generate-content). Local regressions: `cargo test -p nyro-llm --test anthropic_codec --test gemini_codec --test responses_codec --test responses_runtime --test protocol_matrix`.
+
+## Function parameter schemas
+
+The strict path preserves JSON Schema objects in OpenAI Chat `parameters`, Responses `parameters`, Anthropic `input_schema` and Gemini `parametersJsonSchema`. It does not remove `$ref`, `$defs`, `additionalProperties` or other constraints, resolve references, rewrite defaults, or repair schemas. Missing parameters keep the existing no-parameter conversion. Function names must be nonblank and supplied parameter schemas must be JSON objects; this is envelope validation, not a full JSON Schema validator or a guarantee that every model supports every keyword. Argument execution/validation remains the client's responsibility.
+
+OpenAI Chat `strict:false` is accepted for all four destinations. `strict:true` is preserved for OpenAI Chat/Responses and makes Anthropic/Gemini destinations ineligible in the current strict codecs. Responses ingress still requires an explicit boolean `strict`; outgoing Responses always supplies it, defaulting to `false` when the source does not require strict enforcement. Nyro does not add `required` or `additionalProperties:false` to obtain strict-mode compatibility. See [OpenAI function strict mode](https://developers.openai.com/api/docs/guides/function-calling#strict-mode).
+
+Gemini's native `parameters` uses a different Schema dialect and is converted to JSON Schema before destination selection:
+
+| Native Schema field | Strict conversion |
+|---|---|
+| Known `type` names | Lowercase JSON Schema types; unknown types are rejected. |
+| `properties`, `items`, `anyOf` | Recursively convert only schema positions; `anyOf` must be a nonempty array. |
+| `nullable:true` | Add `null` to the explicit type. Combinations with `enum` or `anyOf` are rejected rather than assuming how the constraints interact. |
+| `minItems`/`maxItems`, `minProperties`/`maxProperties`, `minLength`/`maxLength` | Convert nonnegative int64 decimal strings or integer values to JSON numbers, without rounding. |
+| String `enum`, `required`, `minimum`/`maximum`, `title`, `description`, `format`, `pattern` | Validate field shapes and preserve values. Native enum is supported only for string types. |
+| `default` | Preserve literal JSON data without recursively treating it as a schema. |
+| Other native fields, including `propertyOrdering`, `example`, `$ref` and `additionalProperties` | Reject without pruning. Use `parametersJsonSchema` for JSON Schema objects; matching opt-in native forwarding retains its existing contract. |
+
+These checks do not prove satisfiability, resolve references or emulate vendor enforcement. See [Gemini Schema and FunctionDeclaration](https://ai.google.dev/api/generate-content#Schema). Regressions: `cargo test -p nyro-llm --test tool_schema_codec --test responses_runtime`.
 
 ## Opt-in OpenAI Chat native compatibility
 

--- a/docs/standalone/rust-proxy_CN.md
+++ b/docs/standalone/rust-proxy_CN.md
@@ -243,7 +243,27 @@ curl http://127.0.0.1:19530/v1beta/models/gemini-default:generateContent \
 | Gemini 结果缺少 ID | 只有 pending 函数名唯一对应一个调用时才解析；显式 ID 还必须匹配函数名。为缺少 ID 的调用生成的 ID 避开整段历史中已有的显式 ID。 |
 | Gemini 文本与函数结果混排 | 按原顺序解码成独立 IR 消息。Anthropic／Gemini 目标拒绝文本打断尚未完成的结果批次；可表达该历史的 OpenAI Chat／Responses 目标保留顺序。 |
 
-不通过合成调用或丢弃内容修复历史。跨协议 thinking／签名映射、媒体工具结果和 Schema 改写不属于本轮范围。参考：[Anthropic 工具结果](https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls)、[Gemini FunctionResponse](https://ai.google.dev/api/generate-content)。本地回归：`cargo test -p nyro-llm --test anthropic_codec --test gemini_codec --test responses_codec --test responses_runtime --test protocol_matrix`。
+不通过合成调用或丢弃内容修复历史。跨协议 thinking／签名映射和媒体工具结果仍不支持；函数 Schema 转换见下文。参考：[Anthropic 工具结果](https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls)、[Gemini FunctionResponse](https://ai.google.dev/api/generate-content)。本地回归：`cargo test -p nyro-llm --test anthropic_codec --test gemini_codec --test responses_codec --test responses_runtime --test protocol_matrix`。
+
+## 函数参数 Schema
+
+严格路径保留 OpenAI Chat `parameters`、Responses `parameters`、Anthropic `input_schema` 和 Gemini `parametersJsonSchema` 中的 JSON Schema 对象，不删除 `$ref`、`$defs`、`additionalProperties` 等约束，不展开引用、不改写默认值，也不修复 Schema。缺省参数沿用现有无参数转换。函数名必须非空白，提供的参数 Schema 必须是 JSON 对象；这是函数定义外层的校验，不是完整 JSON Schema 校验器，也不保证所有模型都支持每个关键字。工具参数的执行与校验仍由客户端负责。
+
+OpenAI Chat `strict:false` 可转换到四种目标；`strict:true` 在 OpenAI Chat／Responses 间保留，在当前严格 codec 中使 Anthropic／Gemini 目标不再符合条件。Responses 入口仍要求显式布尔 `strict`，发往 Responses 时始终提供该字段，来源未要求严格执行时使用 `false`。Nyro 不通过补充 `required` 或 `additionalProperties:false` 获得严格模式兼容。参考：[OpenAI 函数严格模式](https://developers.openai.com/api/docs/guides/function-calling#strict-mode)。
+
+Gemini 原生 `parameters` 使用不同的 Schema 方言，在选择目标前转换为 JSON Schema：
+
+| 原生 Schema 字段 | 严格转换 |
+|---|---|
+| 已知 `type` 名称 | 转为小写 JSON Schema 类型；未知类型拒绝。 |
+| `properties`、`items`、`anyOf` | 仅在 Schema 位置递归转换；`anyOf` 必须是非空数组。 |
+| `nullable:true` | 在显式类型中加入 `null`；与 `enum` 或 `anyOf` 同时使用时拒绝，不推测约束的组合语义。 |
+| `minItems`／`maxItems`、`minProperties`／`maxProperties`、`minLength`／`maxLength` | 非负 int64 十进制字符串或整数值转为 JSON 数字，不舍入。 |
+| 字符串 `enum`、`required`、`minimum`／`maximum`、`title`、`description`、`format`、`pattern` | 校验字段形状并保留值；原生 enum 仅支持字符串类型。 |
+| `default` | 保留字面 JSON 数据，不将其递归当成 Schema。 |
+| 其他原生字段，包括 `propertyOrdering`、`example`、`$ref` 和 `additionalProperties` | 明确拒绝，不裁剪。JSON Schema 对象使用 `parametersJsonSchema`；匹配的显式原生转发保持现有契约。 |
+
+这些检查不证明约束可满足，不展开引用，也不模拟厂商执行。参考：[Gemini Schema 与 FunctionDeclaration](https://ai.google.dev/api/generate-content#Schema)。回归：`cargo test -p nyro-llm --test tool_schema_codec --test responses_runtime`。
 
 ## 显式开启 OpenAI Chat 原生兼容
 


### PR DESCRIPTION
Convert Gemini Schema counts and nested types without pruning constraints or rewriting literal defaults. Reject ambiguous or unsupported mappings.

Allow explicit non-strict tools across protocols while retaining strict backend eligibility. Validate function envelopes at codec boundaries.