### PR TITLE
feat(llm): convert user image inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2989,6 +2989,7 @@ name = "nyro-llm"
 version = "1.8.3"
 dependencies = [
  "axum",
+ "base64 0.22.1",
  "bytes",
  "futures",
  "nyro-limit",

--- a/crates/nyro-llm/Cargo.toml
+++ b/crates/nyro-llm/Cargo.toml
@@ -19,6 +19,7 @@ reqwest.workspace = true
 tracing.workspace = true
 futures = "0.3"
 bytes = "1"
+base64 = "0.22"
 rand = "0.8"
 
 [dev-dependencies]

--- a/crates/nyro-llm/src/codec/anthropic.rs
+++ b/crates/nyro-llm/src/codec/anthropic.rs
@@ -61,6 +61,23 @@ fn decode_messages(messages: Vec<wire::Message>) -> Result<Vec<Value>, CodecErro
                     }
                     parts.push(json!({"type":"text","text":text}));
                 }
+                wire::Block::Image { source } => {
+                    if m.role != "user" {
+                        return Err(bad("images require a user message"));
+                    }
+                    let url = match source {
+                        wire::ImageSource::Base64 { media_type, data } => {
+                            format!("data:{media_type};base64,{data}")
+                        }
+                        wire::ImageSource::Url { url } => {
+                            if url.starts_with("data:") {
+                                return Err(bad("URL image source requires HTTP(S)"));
+                            }
+                            url
+                        }
+                    };
+                    parts.push(json!({"type":"image_url","image_url":{"url":url}}));
+                }
                 wire::Block::ToolUse { id, name, input } => {
                     if m.role != "assistant"
                         || !input.is_object()
@@ -182,7 +199,7 @@ pub fn decode_chat(value: Value) -> Result<ChatRequest, CodecError> {
     }
     Ok(request)
 }
-fn content_parts(c: &Option<Content>) -> Result<Vec<Value>, CodecError> {
+fn content_parts(c: &Option<Content>, images: bool) -> Result<Vec<Value>, CodecError> {
     match c {
         None => Ok(vec![]),
         Some(Content::Text(t)) => Ok(vec![json!({"type":"text","text":t})]),
@@ -190,6 +207,16 @@ fn content_parts(c: &Option<Content>) -> Result<Vec<Value>, CodecError> {
             .iter()
             .map(|p| match p {
                 ContentPart::Text { text } => Ok(json!({"type":"text","text":text})),
+                ContentPart::ImageUrl { image_url } if images => {
+                    super::image::default_detail(image_url)?;
+                    let source = match super::image::source(image_url)? {
+                        super::image::Source::Url(url) => json!({"type":"url","url":url}),
+                        super::image::Source::Base64 { mime, data } => {
+                            json!({"type":"base64","media_type":mime,"data":data})
+                        }
+                    };
+                    Ok(json!({"type":"image","source":source}))
+                }
                 _ => Err(bad("unsupported non-text content")),
             })
             .collect(),
@@ -274,7 +301,7 @@ pub fn encode_chat(r: &ChatRequest) -> Result<Value, CodecError> {
         if m.name.is_some() || m.refusal.is_some() || m.audio.is_some() {
             return Err(bad("unsupported message option"));
         }
-        let mut content = content_parts(&m.content)?;
+        let mut content = content_parts(&m.content, m.role == Role::User)?;
         content.extend(call_blocks(&m.tool_calls)?);
         match m.role {
             Role::System | Role::Developer => {
@@ -462,7 +489,7 @@ pub fn encode_chat_response(r: &ChatResponse) -> Result<Value, CodecError> {
     {
         return Err(bad("unsupported response fields"));
     }
-    let mut content = content_parts(&c.message.content)?;
+    let mut content = content_parts(&c.message.content, false)?;
     content.extend(call_blocks(&c.message.tool_calls)?);
     let u = r
         .usage

--- a/crates/nyro-llm/src/codec/gemini.rs
+++ b/crates/nyro-llm/src/codec/gemini.rs
@@ -19,7 +19,7 @@ fn message(role: Role) -> Message {
         audio: None,
     }
 }
-fn texts(content: &Option<Content>) -> Result<Vec<w::Part>, CodecError> {
+fn content_parts(content: &Option<Content>, images: bool) -> Result<Vec<w::Part>, CodecError> {
     match content {
         None => Ok(vec![]),
         Some(Content::Text(s)) => Ok(vec![w::Part {
@@ -33,6 +33,24 @@ fn texts(content: &Option<Content>) -> Result<Vec<w::Part>, CodecError> {
                     text: Some(text.clone()),
                     ..Default::default()
                 }),
+                ContentPart::ImageUrl { image_url } if images => {
+                    super::image::default_detail(image_url)?;
+                    let super::image::Source::Base64 { mime, data } =
+                        super::image::source(image_url)?
+                    else {
+                        return Err(bad("Gemini image conversion requires inline data"));
+                    };
+                    if mime == "image/gif" {
+                        return Err(bad("GIF images unsupported by Gemini"));
+                    }
+                    Ok(w::Part {
+                        inline_data: Some(w::Blob {
+                            mime_type: mime.into(),
+                            data: data.into(),
+                        }),
+                        ..Default::default()
+                    })
+                }
                 _ => Err(bad("Gemini supports text content only in this increment")),
             })
             .collect(),
@@ -40,6 +58,7 @@ fn texts(content: &Option<Content>) -> Result<Vec<w::Part>, CodecError> {
 }
 fn check_part(p: &w::Part) -> Result<(), CodecError> {
     if usize::from(p.text.is_some())
+        + usize::from(p.inline_data.is_some())
         + usize::from(p.function_call.is_some())
         + usize::from(p.function_response.is_some())
         != 1
@@ -107,6 +126,21 @@ pub fn decode_chat(value: Value, model: &str, streaming: bool) -> Result<ChatReq
                     ));
                 }
                 parts.push(ContentPart::Text { text });
+            } else if let Some(blob) = p.inline_data {
+                if role != Role::User
+                    || !matches!(
+                        blob.mime_type.as_str(),
+                        "image/png" | "image/jpeg" | "image/webp"
+                    )
+                {
+                    return Err(bad("unsupported inline image type or role"));
+                }
+                parts.push(ContentPart::ImageUrl {
+                    image_url: ImageUrl {
+                        url: format!("data:{};base64,{}", blob.mime_type, blob.data),
+                        detail: None,
+                    },
+                });
             } else if let Some(c) = p.function_call {
                 if role != Role::Assistant {
                     return Err(bad("function calls require model role"));
@@ -379,7 +413,7 @@ pub fn encode_chat(r: &ChatRequest) -> Result<Value, CodecError> {
         {
             return Err(bad("unsupported message metadata"));
         }
-        let mut parts = texts(&m.content)?;
+        let mut parts = content_parts(&m.content, m.role == Role::User)?;
         if m.role == Role::Tool {
             if parts.len() > 1 {
                 return Err(bad(
@@ -710,7 +744,7 @@ pub fn encode_chat_response(r: &ChatResponse) -> Result<Value, CodecError> {
         {
             return Err(bad("unsupported response payload"));
         }
-        let mut parts = texts(&c.message.content)?;
+        let mut parts = content_parts(&c.message.content, false)?;
         if let Some(calls) = &c.message.tool_calls {
             for ToolCall::Function { id, function } in calls {
                 let args: Value = serde_json::from_str(&function.arguments)?;

--- a/crates/nyro-llm/src/codec/image.rs
+++ b/crates/nyro-llm/src/codec/image.rs
@@ -1,0 +1,48 @@
+//! Image envelope conversion only: no fetching, image decoding or transcoding.
+use super::CodecError;
+use crate::ir::ImageUrl;
+use base64::{Engine, engine::general_purpose::STANDARD};
+
+pub(super) enum Source<'a> {
+    Url(&'a str),
+    Base64 { mime: &'a str, data: &'a str },
+}
+
+pub(super) fn source(image: &ImageUrl) -> Result<Source<'_>, CodecError> {
+    let bad = || CodecError("unsupported or invalid image source/detail".into());
+    if image
+        .detail
+        .as_deref()
+        .is_some_and(|d| !matches!(d, "auto" | "low" | "high" | "original"))
+    {
+        return Err(bad());
+    }
+    if let Some(value) = image.url.strip_prefix("data:") {
+        let (mime, data) = value.split_once(";base64,").ok_or_else(bad)?;
+        if !matches!(
+            mime,
+            "image/png" | "image/jpeg" | "image/webp" | "image/gif"
+        ) || data.is_empty()
+        {
+            return Err(bad());
+        }
+        STANDARD.decode(data).map_err(|_| bad())?;
+        Ok(Source::Base64 { mime, data })
+    } else {
+        let url = reqwest::Url::parse(&image.url).map_err(|_| bad())?;
+        if !matches!(url.scheme(), "http" | "https") || url.host_str().is_none() {
+            return Err(bad());
+        }
+        Ok(Source::Url(&image.url))
+    }
+}
+
+pub(super) fn default_detail(image: &ImageUrl) -> Result<(), CodecError> {
+    if image.detail.as_deref().is_some_and(|d| d != "auto") {
+        Err(CodecError(
+            "image detail cannot be represented by this destination".into(),
+        ))
+    } else {
+        Ok(())
+    }
+}

--- a/crates/nyro-llm/src/codec/mod.rs
+++ b/crates/nyro-llm/src/codec/mod.rs
@@ -1,3 +1,4 @@
+mod image;
 pub mod openai;
 
 /// A rejected or unsupported payload; HTTP ingress sanitizes details before responding.

--- a/crates/nyro-llm/src/codec/openai.rs
+++ b/crates/nyro-llm/src/codec/openai.rs
@@ -72,6 +72,16 @@ fn validate_chat(request: &ChatRequest) -> Result<(), CodecError> {
         }
     }
     for message in &request.messages {
+        if let Some(Content::Parts(parts)) = &message.content {
+            for part in parts {
+                if let ContentPart::ImageUrl { image_url } = part {
+                    if message.role != Role::User {
+                        return Err(invalid("images require a user message"));
+                    }
+                    super::image::source(image_url)?;
+                }
+            }
+        }
         if message.tool_error && message.role != Role::Tool {
             return Err(invalid("tool_error requires a tool result"));
         }

--- a/crates/nyro-llm/src/codec/openai/responses.rs
+++ b/crates/nyro-llm/src/codec/openai/responses.rs
@@ -83,6 +83,16 @@ pub fn decode_chat(value: Value) -> Result<ChatRequest, CodecError> {
                                     parts
                                         .into_iter()
                                         .map(|part| match part {
+                                            wire::InputPart::InputImage { image_url, detail }
+                                                if role == Role::User =>
+                                            {
+                                                Ok(ContentPart::ImageUrl {
+                                                    image_url: ImageUrl {
+                                                        url: image_url,
+                                                        detail,
+                                                    },
+                                                })
+                                            }
                                             wire::InputPart::InputText { text } => {
                                                 Ok(ContentPart::Text { text })
                                             }
@@ -219,7 +229,11 @@ pub fn decode_chat(value: Value) -> Result<ChatRequest, CodecError> {
     super::validate_chat(&request)?;
     Ok(request)
 }
-fn content_parts(content: &Content, assistant: bool) -> Result<Vec<Value>, CodecError> {
+fn content_parts(
+    content: &Content,
+    assistant: bool,
+    images: bool,
+) -> Result<Vec<Value>, CodecError> {
     match content {
         Content::Text(text) => Ok(vec![if assistant {
             json!({"type":"output_text","text":text,"annotations":[]})
@@ -234,6 +248,14 @@ fn content_parts(content: &Content, assistant: bool) -> Result<Vec<Value>, Codec
                 } else {
                     json!({"type":"input_text","text":text})
                 }),
+                ContentPart::ImageUrl { image_url } if images => {
+                    super::super::image::source(image_url)?;
+                    let mut part = json!({"type":"input_image","image_url":image_url.url});
+                    if let Some(detail) = &image_url.detail {
+                        part["detail"] = json!(detail);
+                    }
+                    Ok(part)
+                }
                 ContentPart::Refusal { refusal } if assistant => {
                     Ok(json!({"type":"refusal","refusal":refusal}))
                 }
@@ -281,7 +303,7 @@ pub fn encode_chat(r: &ChatRequest) -> Result<Value, CodecError> {
         if m.role == Role::Tool {
             let output = match &m.content {
                 Some(Content::Text(s)) => json!(s),
-                Some(content @ Content::Parts(_)) => json!(content_parts(content, false)?),
+                Some(content @ Content::Parts(_)) => json!(content_parts(content, false, false)?),
                 None => return Err(bad("function result requires text")),
             };
             if m.refusal.is_some() {
@@ -295,7 +317,7 @@ pub fn encode_chat(r: &ChatRequest) -> Result<Value, CodecError> {
         let mut parts = m
             .content
             .as_ref()
-            .map(|c| content_parts(c, m.role == Role::Assistant))
+            .map(|c| content_parts(c, m.role == Role::Assistant, m.role == Role::User))
             .transpose()?
             .unwrap_or_default();
         if let Some(refusal) = &m.refusal {
@@ -683,7 +705,7 @@ pub fn encode_chat_response(r: &ChatResponse) -> Result<Value, CodecError> {
     let mut parts = m
         .content
         .as_ref()
-        .map(|c| content_parts(c, true))
+        .map(|c| content_parts(c, true, false))
         .transpose()?
         .unwrap_or_default();
     if let Some(refusal) = &m.refusal {

--- a/crates/nyro-llm/tests/anthropic_codec.rs
+++ b/crates/nyro-llm/tests/anthropic_codec.rs
@@ -121,7 +121,7 @@ fn rejects_lossy_options_and_missing_max_tokens() {
     request.generation.max_tokens = Some(4);
     request.generation.seed = Some(7);
     assert!(encode_chat(&request).is_err());
-    assert!(decode_chat(json!({"model":"m","max_tokens":4,"messages":[{"role":"user","content":[{"type":"image","source":{"type":"url","url":"https://example.com/a.png"}}]}]})).is_err());
+    assert!(decode_chat(json!({"model":"m","max_tokens":4,"messages":[{"role":"user","content":[{"type":"image","source":{"type":"file","file_id":"file-1"}}]}]})).is_err());
 }
 #[test]
 fn malformed_and_oversized_tool_streams_fail_without_done() {

--- a/crates/nyro-llm/tests/image_codec.rs
+++ b/crates/nyro-llm/tests/image_codec.rs
@@ -1,0 +1,211 @@
+use nyro_llm::{
+    codec::{anthropic, gemini, openai},
+    ir::*,
+};
+use nyro_protocol::framing::Event;
+use serde_json::{Value, json};
+
+// Valid 1x1 PNG; codecs preserve bytes and leave image decoding to the vendor.
+const PNG: &str =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC";
+fn image_url() -> String {
+    format!("data:image/png;base64,{PNG}")
+}
+fn chat(url: &str, detail: Option<&str>) -> Value {
+    let mut image = json!({"url":url});
+    if let Some(detail) = detail {
+        image["detail"] = json!(detail);
+    }
+    json!({"model":"m","max_tokens":64,"messages":[{"role":"user","content":[{"type":"text","text":"before"},{"type":"image_url","image_url":image},{"type":"text","text":"after"}]}]})
+}
+fn anthro(source: Value) -> Value {
+    json!({"model":"m","max_tokens":64,"messages":[{"role":"user","content":[{"type":"text","text":"before"},{"type":"image","source":source},{"type":"text","text":"after"}]}]})
+}
+fn responses(url: &str, detail: Option<&str>) -> Value {
+    let mut image = json!({"type":"input_image","image_url":url});
+    if let Some(detail) = detail {
+        image["detail"] = json!(detail);
+    }
+    json!({"model":"m","max_output_tokens":64,"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"before"},image,{"type":"input_text","text":"after"}]}]})
+}
+fn gem() -> Value {
+    json!({"contents":[{"role":"user","parts":[{"text":"before"},{"inlineData":{"mimeType":"image/png","data":PNG}},{"text":"after"}]}],"generationConfig":{"maxOutputTokens":64}})
+}
+
+#[test]
+fn inline_images_keep_mime_bytes_and_text_order_across_four_codecs() {
+    let a = anthro(json!({"type":"base64","media_type":"image/png","data":PNG}));
+    let expected_chat = chat(&image_url(), None);
+    let expected_responses = responses(&image_url(), None);
+    for r in [
+        openai::decode_chat(expected_chat.clone()).unwrap(),
+        anthropic::decode_chat(a.clone()).unwrap(),
+        openai::responses::decode_chat(expected_responses.clone()).unwrap(),
+        gemini::decode_chat(gem(), "m", false).unwrap(),
+    ] {
+        assert_eq!(
+            openai::encode_chat(&r).unwrap()["messages"],
+            expected_chat["messages"]
+        );
+        assert_eq!(
+            anthropic::encode_chat(&r).unwrap()["messages"],
+            a["messages"]
+        );
+        assert_eq!(
+            openai::responses::encode_chat(&r).unwrap()["input"],
+            expected_responses["input"]
+        );
+        assert_eq!(
+            gemini::encode_chat(&r).unwrap()["contents"],
+            gem()["contents"]
+        );
+    }
+}
+#[test]
+fn remote_urls_and_detail_have_destination_specific_boundaries() {
+    let url = "https://images.example.test/photo.png?token=opaque";
+    let a = anthro(json!({"type":"url","url":url}));
+    let r = anthropic::decode_chat(a.clone()).unwrap();
+    assert_eq!(
+        openai::encode_chat(&r).unwrap()["messages"],
+        chat(url, None)["messages"]
+    );
+    assert_eq!(
+        openai::responses::encode_chat(&r).unwrap()["input"],
+        responses(url, None)["input"]
+    );
+    assert_eq!(
+        anthropic::encode_chat(&r).unwrap()["messages"],
+        a["messages"]
+    );
+    assert!(gemini::encode_chat(&r).is_err());
+    for detail in ["auto", "low", "high", "original"] {
+        let r = openai::responses::decode_chat(responses(&image_url(), Some(detail))).unwrap();
+        assert_eq!(
+            openai::encode_chat(&r).unwrap()["messages"],
+            chat(&image_url(), Some(detail))["messages"]
+        );
+        assert_eq!(
+            openai::responses::encode_chat(&r).unwrap()["input"],
+            responses(&image_url(), Some(detail))["input"]
+        );
+        assert_eq!(anthropic::encode_chat(&r).is_ok(), detail == "auto");
+        assert_eq!(gemini::encode_chat(&r).is_ok(), detail == "auto");
+    }
+}
+#[test]
+fn malformed_images_and_unsupported_sources_are_rejected() {
+    for url in [
+        "",
+        "file:///tmp/image.png",
+        "https://",
+        "data:image/png;base64,",
+        "data:image/png;base64,not_base64",
+        "data:text/plain;base64,YQ==",
+        "data:image/png,raw",
+    ] {
+        assert!(openai::decode_chat(chat(url, None)).is_err(), "{url}");
+        assert!(
+            openai::responses::decode_chat(responses(url, None)).is_err(),
+            "{url}"
+        );
+    }
+    assert!(openai::decode_chat(chat(&image_url(), Some("unknown"))).is_err());
+    assert!(anthropic::decode_chat(anthro(json!({"type":"file","file_id":"file-1"}))).is_err());
+    assert!(
+        anthropic::decode_chat(anthro(
+            json!({"type":"base64","media_type":"image/png","data":"invalid"})
+        ))
+        .is_err()
+    );
+    let mut v = gem();
+    v["contents"][0]["parts"][1] =
+        json!({"fileData":{"mimeType":"image/png","fileUri":"https://files.example.test/file"}});
+    assert!(gemini::decode_chat(v, "m", false).is_err());
+    let mut v = gem();
+    v["contents"][0]["parts"][1]["text"] = json!("also text");
+    assert!(gemini::decode_chat(v, "m", false).is_err());
+    let mut v = gem();
+    v["contents"][0]["parts"][1]["inlineData"]["mimeType"] = json!("audio/wav");
+    assert!(gemini::decode_chat(v, "m", false).is_err());
+}
+#[test]
+fn images_are_user_input_only_including_direct_ir_encoders() {
+    for role in [Role::System, Role::Developer, Role::Assistant, Role::Tool] {
+        let mut r = openai::decode_chat(chat(&image_url(), None)).unwrap();
+        r.messages[0].role = role.clone();
+        if role == Role::Tool {
+            r.messages[0].tool_call_id = Some("call".into());
+        }
+        assert!(openai::encode_chat(&r).is_err());
+        assert!(openai::responses::encode_chat(&r).is_err());
+        assert!(anthropic::encode_chat(&r).is_err());
+        assert!(gemini::encode_chat(&r).is_err());
+    }
+    let mut v = anthro(json!({"type":"base64","media_type":"image/png","data":PNG}));
+    v["messages"][0]["role"] = json!("assistant");
+    assert!(anthropic::decode_chat(v).is_err());
+    let mut v = responses(&image_url(), None);
+    v["input"][0]["role"] = json!("system");
+    assert!(openai::responses::decode_chat(v).is_err());
+    let mut v = gem();
+    v["contents"][0]["role"] = json!("model");
+    assert!(gemini::decode_chat(v, "m", false).is_err());
+}
+#[test]
+fn accepting_input_images_does_not_silently_accept_generated_images() {
+    let block =
+        json!({"type":"image","source":{"type":"base64","media_type":"image/png","data":PNG}});
+    let v = json!({"id":"r","type":"message","role":"assistant","model":"m","content":[block],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}});
+    assert!(anthropic::decode_chat_response(v).is_err());
+    let mut decoder = anthropic::StreamDecoder::new();
+    decoder.push(&Event { event:Some("message_start".into()), data:json!({"type":"message_start","message":{"id":"r","type":"message","role":"assistant","model":"m","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}).to_string() }).unwrap();
+    assert!(
+        decoder
+            .push(&Event {
+                event: Some("content_block_start".into()),
+                data: json!({"type":"content_block_start","index":0,"content_block":block})
+                    .to_string()
+            })
+            .is_err()
+    );
+
+    let v = json!({"candidates":[{"content":{"role":"model","parts":[{"inlineData":{"mimeType":"image/png","data":PNG}}]},"finishReason":"STOP"}]});
+    assert!(gemini::decode_chat_response(v.clone()).is_err());
+    let mut decoder = gemini::StreamDecoder::new();
+    assert!(
+        decoder
+            .push(&Event {
+                event: None,
+                data: v.to_string()
+            })
+            .is_err()
+    );
+}
+
+#[test]
+fn image_mime_types_are_preserved_with_gemini_gif_boundary() {
+    for mime in ["image/png", "image/jpeg", "image/webp", "image/gif"] {
+        // These are envelope tests: intentionally do not claim pixel/MIME sniffing.
+        let url = format!("data:{mime};base64,{PNG}");
+        let r = openai::decode_chat(chat(&url, None)).unwrap();
+        let a = anthropic::encode_chat(&r).unwrap();
+        assert_eq!(
+            a["messages"][0]["content"][1]["source"],
+            json!({"type":"base64","media_type":mime,"data":PNG})
+        );
+        assert_eq!(
+            openai::responses::encode_chat(&r).unwrap()["input"][0]["content"][1]["image_url"],
+            url
+        );
+        let g = gemini::encode_chat(&r);
+        if mime == "image/gif" {
+            assert!(g.is_err());
+        } else {
+            assert_eq!(
+                g.unwrap()["contents"][0]["parts"][1]["inlineData"],
+                json!({"mimeType":mime,"data":PNG})
+            );
+        }
+    }
+}

--- a/crates/nyro-llm/tests/responses_codec.rs
+++ b/crates/nyro-llm/tests/responses_codec.rs
@@ -128,10 +128,11 @@ fn function_result_rejects_non_input_text_parts_and_invalid_shapes() {
         json!({"type":"input_audio","input_audio":{"data":"YQ==","format":"wav"}}),
         json!({"type":"refusal","refusal":"lost"}),
     ] {
-        let request = openai::decode_chat(json!({"model":"m","messages":[
-            {"role":"tool","tool_call_id":"call1","content":[part]}
+        let mut request = openai::decode_chat(json!({"model":"m","messages":[
+            {"role":"tool","tool_call_id":"call1","content":"result"}
         ]}))
         .unwrap();
+        request.messages[0].content = Some(serde_json::from_value(json!([part])).unwrap());
         assert!(encode_chat(&request).is_err());
     }
 }
@@ -154,7 +155,7 @@ fn request_rejects_unrepresentable_semantics() {
     }
     for item in [
         json!({"type":"item_reference","id":"m"}),
-        json!({"role":"user","content":[{"type":"input_image","image_url":"https://x"}]}),
+        json!({"role":"user","content":[{"type":"input_image","file_id":"file-1"}]}),
         json!({"type":"reasoning","summary":[]}),
     ] {
         assert!(decode_chat(json!({"model":"m","input":[item]})).is_err());

--- a/crates/nyro-llm/tests/responses_runtime.rs
+++ b/crates/nyro-llm/tests/responses_runtime.rs
@@ -961,7 +961,7 @@ async fn responses_protected_intake_and_unsupported_controls_never_dispatch() {
         json!({"reasoning":{"effort":"high"}}),
         json!({"tools":[{"type":"web_search"}]}),
         json!({"input":[{"type":"item_reference","id":"msg_prior"}]}),
-        json!({"input":[{"role":"user","content":[{"type":"input_image","image_url":"https://example.test/image.png"}]}]}),
+        json!({"input":[{"role":"user","content":[{"type":"input_image","file_id":"file-1"}]}]}),
         json!({"unknown_control":true}),
     ] {
         let mut payload = json!({"model":"public","input":"Hi","max_output_tokens":32});
@@ -1549,6 +1549,162 @@ async fn gemini_schema_normalization_and_rejections_precede_network_dispatch() {
             to_bytes(response.into_body(), 65536).await.unwrap();
             assert_eq!(fixture.calls.lock().unwrap().len(), before);
             assert_eq!(limit.available(), 1);
+        }
+    }
+}
+
+const IMAGE_PNG: &str =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC";
+fn image_content(format: &str, remote: bool, detail: Option<&str>) -> Value {
+    let url = if remote {
+        "https://images.example.test/image.png?signature=opaque".into()
+    } else {
+        format!("data:image/png;base64,{IMAGE_PNG}")
+    };
+    let (before, mut image, after) = match format {
+        "openai" => (
+            json!({"type":"text","text":"before"}),
+            json!({"type":"image_url","image_url":{"url":url}}),
+            json!({"type":"text","text":"after"}),
+        ),
+        "responses" => (
+            json!({"type":"input_text","text":"before"}),
+            json!({"type":"input_image","image_url":url}),
+            json!({"type":"input_text","text":"after"}),
+        ),
+        "anthropic" => (
+            json!({"type":"text","text":"before"}),
+            json!({"type":"image","source":if remote {json!({"type":"url","url":url})} else {json!({"type":"base64","media_type":"image/png","data":IMAGE_PNG})}}),
+            json!({"type":"text","text":"after"}),
+        ),
+        _ => (
+            json!({"text":"before"}),
+            json!({"inlineData":{"mimeType":"image/png","data":IMAGE_PNG}}),
+            json!({"text":"after"}),
+        ),
+    };
+    if let Some(detail) = detail {
+        match format {
+            "openai" => image["image_url"]["detail"] = json!(detail),
+            "responses" => image["detail"] = json!(detail),
+            _ => {}
+        }
+    }
+    json!([before, image, after])
+}
+fn input_image_pointer(format: &str) -> &'static str {
+    match format {
+        "responses" => "/input/0/content",
+        "gemini" => "/contents/0/parts",
+        _ => "/messages/0/content",
+    }
+}
+async fn image_request(
+    format: &str,
+    streaming: bool,
+    remote: bool,
+    detail: Option<&str>,
+) -> Request<Body> {
+    let (parts, body) = request(format, streaming).into_parts();
+    let mut value: Value = serde_json::from_slice(&to_bytes(body, 65536).await.unwrap()).unwrap();
+    if format == "responses" {
+        value["input"] = json!([{"role":"user","content":[]}]);
+    }
+    *value.pointer_mut(input_image_pointer(format)).unwrap() =
+        image_content(format, remote, detail);
+    Request::from_parts(parts, Body::from(value.to_string()))
+}
+#[tokio::test]
+async fn image_inputs_preserve_content_order_and_bytes_without_fetching_urls() {
+    for target in FORMATS {
+        let fixture = upstream(target, "normal").await;
+        let limit = ConcurrencyLimit::new(1).unwrap();
+        let gateway = runtime(&fixture, target, limit.clone(), Options::default());
+        for source in FORMATS {
+            for remote in [false, true] {
+                if remote && source == "gemini" {
+                    continue;
+                }
+                for streaming in [false, true] {
+                    let before = fixture.calls.lock().unwrap().len();
+                    let response = gateway
+                        .handle(
+                            image_request(source, streaming, remote, None).await,
+                            CancellationToken::new(),
+                        )
+                        .await;
+                    let allowed = !(remote && target == "gemini");
+                    assert_eq!(
+                        response.status(),
+                        if allowed {
+                            StatusCode::OK
+                        } else {
+                            StatusCode::BAD_REQUEST
+                        },
+                        "{source} -> {target}, remote={remote}"
+                    );
+                    let body = to_bytes(response.into_body(), 65536).await.unwrap();
+                    assert_eq!(limit.available(), 1);
+                    let calls = fixture.calls.lock().unwrap();
+                    assert_eq!(calls.len(), before + usize::from(allowed));
+                    if !allowed {
+                        continue;
+                    }
+                    assert_eq!(
+                        calls.last().unwrap()["body"]
+                            .pointer(input_image_pointer(target))
+                            .unwrap(),
+                        &image_content(target, remote, None)
+                    );
+                    let result = if streaming {
+                        stream_snapshot(source, &body)
+                    } else {
+                        snapshot(source, &serde_json::from_slice(&body).unwrap())
+                    };
+                    assert_eq!(result["text"], "Hello");
+                }
+            }
+        }
+    }
+}
+#[tokio::test]
+async fn image_detail_is_preserved_or_rejected_before_dispatch() {
+    for target in FORMATS {
+        let fixture = upstream(target, "normal").await;
+        let limit = ConcurrencyLimit::new(1).unwrap();
+        let gateway = runtime(&fixture, target, limit.clone(), Options::default());
+        for source in ["openai", "responses"] {
+            for detail in ["auto", "low", "high", "original"] {
+                let before = fixture.calls.lock().unwrap().len();
+                let response = gateway
+                    .handle(
+                        image_request(source, false, false, Some(detail)).await,
+                        CancellationToken::new(),
+                    )
+                    .await;
+                let allowed = detail == "auto" || matches!(target, "openai" | "responses");
+                assert_eq!(
+                    response.status(),
+                    if allowed {
+                        StatusCode::OK
+                    } else {
+                        StatusCode::BAD_REQUEST
+                    },
+                    "{source} -> {target}, detail={detail}"
+                );
+                to_bytes(response.into_body(), 65536).await.unwrap();
+                assert_eq!(limit.available(), 1);
+                let calls = fixture.calls.lock().unwrap();
+                assert_eq!(calls.len(), before + usize::from(allowed));
+                if allowed {
+                    assert_eq!(
+                        calls.last().unwrap()["body"]
+                            .pointer(input_image_pointer(target))
+                            .unwrap(),
+                        &image_content(target, false, Some(detail))
+                    );
+                }
+            }
         }
     }
 }

--- a/crates/nyro-protocol/src/anthropic.rs
+++ b/crates/nyro-protocol/src/anthropic.rs
@@ -13,6 +13,9 @@ pub enum Block {
     Text {
         text: String,
     },
+    Image {
+        source: ImageSource,
+    },
     ToolUse {
         id: String,
         name: String,
@@ -25,6 +28,12 @@ pub enum Block {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         is_error: Option<bool>,
     },
+}
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum ImageSource {
+    Base64 { media_type: String, data: String },
+    Url { url: String },
 }
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/nyro-protocol/src/gemini.rs
+++ b/crates/nyro-protocol/src/gemini.rs
@@ -26,9 +26,17 @@ pub struct Part {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inline_data: Option<Blob>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub function_call: Option<FunctionCall>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub function_response: Option<FunctionResponse>,
+}
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Blob {
+    pub mime_type: String,
+    pub data: String,
 }
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]

--- a/crates/nyro-protocol/src/openai/responses.rs
+++ b/crates/nyro-protocol/src/openai/responses.rs
@@ -58,6 +58,10 @@ pub enum InputContent {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 pub enum InputPart {
+    InputImage {
+        image_url: String,
+        detail: Option<String>,
+    },
     InputText {
         text: String,
     },

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -490,13 +490,13 @@ Chat 流使用自己的事件类型，不要求所有交互实现流接口。当
 
 ### 8.2 内容模态与操作分开
 
-包含图片或音频内容的对话仍然可以是 Chat。图片生成、图片编辑、音频转写、语音合成等操作在需要时定义自己的请求和结果；不能仅按媒体名称制造装满可选字段的万能结构。如果未来的视频操作是异步任务，还应表达任务提交、状态与产物，而非强套普通同步响应。
+包含图片或音频内容的对话仍然可以是 Chat。当前严格用户图片转换复用既有 `ContentPart::ImageUrl`，由 codec 映射 OpenAI Chat／Responses、Anthropic URL／base64 和 Gemini inlineData；图片来源解析为 `nyro-llm/codec` 私有辅助逻辑。图片不会进入内核，也不新增下载、转码服务或独立 Image 工作负载。图片生成、图片编辑、音频转写、语音合成等操作在需要时定义自己的请求和结果；不能仅按媒体名称制造装满可选字段的万能结构。如果未来的视频操作是异步任务，还应表达任务提交、状态与产物，而非强套普通同步响应。
 
 共享内容引用、错误和用量类型以语义一致为前提。当前 Chat `Message.tool_error` 是工具结果的显式执行失败标志，默认 `false` 且序列化时省略默认值；只允许用于工具结果消息。Anthropic 的 `is_error:true` 映射到该字段，无法保留它的严格目标在发送前被排除。Gemini 结果 JSON 中的 `error` 键不自动推断为该标志。结果文本块保持边界，不通过拼接掩盖目标协议的表达限制。已知的交互核心字段进入类型化 IR；协议特有和供应商特有字段具有明确归属，不把无约束 JSON 作为常规交互数据模型。
 
 ### 8.3 对外复用范围
 
-`nyro-protocol` 独立提供 OpenAI、Anthropic、Gemini 基础协议格式，社区项目解析这些协议时不需要构建 Nyro runtime、内核或数据库。IR 与跨协议转换暂留 `nyro-llm`，本次不承诺一个独立的 IR/转换 SDK。Responses 是 OpenAI 族内的一种 API，与 Chat Completions 共享 Chat workload；上游通过 `kind: openai` 加 `api: responses` 选择，不新增 Provider 族或 crate。现有 Chat IR 支持无状态文本、拒绝、客户端函数调用／结果及用量，不能完整承载 Responses 的服务端会话、item 引用、内置工具或 reasoning items，因此严格转换路径明确拒绝这些语义。匹配的 Responses 原生模式可保留 reasoning 历史和媒体等 JSON 扩展，但仍不支持托管会话、item 引用或内置工具；这些字段不进入公共 IR。函数参数 Schema 仍由 codec 处理：JSON Schema 对象保留原字段，Gemini 原生 Schema 只转换明确支持的方言子集，无法保留的约束拒绝。当前不引入通用 Schema 校验框架，也不在内核或执行链中展开引用、裁剪约束或验证工具执行参数。具体转换与流状态边界见实验性代理指南。
+`nyro-protocol` 独立提供 OpenAI、Anthropic、Gemini 基础协议格式，社区项目解析这些协议时不需要构建 Nyro runtime、内核或数据库。IR 与跨协议转换暂留 `nyro-llm`，本次不承诺一个独立的 IR/转换 SDK。Responses 是 OpenAI 族内的一种 API，与 Chat Completions 共享 Chat workload；上游通过 `kind: openai` 加 `api: responses` 选择，不新增 Provider 族或 crate。现有 Chat IR 支持无状态文本、用户图片、拒绝、客户端函数调用／结果及用量，不能完整承载 Responses 的服务端会话、item 引用、内置工具或 reasoning items，因此严格转换路径明确拒绝这些语义。匹配的 Responses 原生模式可保留 reasoning 历史和媒体等 JSON 扩展，但仍不支持托管会话、item 引用或内置工具；这些字段不进入公共 IR。函数参数 Schema 仍由 codec 处理：JSON Schema 对象保留原字段，Gemini 原生 Schema 只转换明确支持的方言子集，无法保留的约束拒绝。当前不引入通用 Schema 校验框架，也不在内核或执行链中展开引用、裁剪约束或验证工具执行参数。具体转换与流状态边界见实验性代理指南。
 
 ## 9. 共享安全、限制与观测能力
 
@@ -558,7 +558,7 @@ schema 的所有权不因共用数据库而合并。修改实际迁移源时仍�
 | 阶段 | 当前进度 | 差异跟踪 |
 |---|---|---|
 | 内核、代际、文件配置 | 基础机制已落地；SIGHUP 重载已有回归 | 后续能力必须保持生命周期与清理约束 |
-| LLM 数据面 | 主要执行链已落地；模型发现 G01 已补齐，G02 已支持显式开启 OpenAI Chat／无状态 Responses／Anthropic Messages／单候选 Gemini 原生 JSON/SSE 保真；G04 已补充 Anthropic／Gemini 完整工具结果批次、显式错误状态边界、文本结果块与 Gemini ID／顺序校验；函数 Schema 已补充 JSON 约束保留、Gemini 方言转换与 strict 目标边界；整体兼容对齐未完成 | G02–G09 |
+| LLM 数据面 | 主要执行链已落地；模型发现 G01 已补齐，G02 已支持显式开启 OpenAI Chat／无状态 Responses／Anthropic Messages／单候选 Gemini 原生 JSON/SSE 保真；G04 已补充 Anthropic／Gemini 完整工具结果批次、显式错误状态边界、文本结果块与 Gemini ID／顺序校验；函数 Schema 已补充 JSON 约束保留、Gemini 方言转换与 strict 目标边界；G03 已补充用户图片输入及目标限制；整体兼容对齐未完成 | G02–G09 |
 | 控制面、存储、管理与持久化观测 | 尚未接入新架构 | G10–G12 |
 | 工具、部署和旧入口切换 | 尚未完成切换验收 | G11、G13 |
 

--- a/docs/design/rust-migration-gaps.md
+++ b/docs/design/rust-migration-gaps.md
@@ -1,6 +1,6 @@
 # Rust 迁移差异审计
 
-审计基线：`d943c174`（2026-09-09，含 PR #323）。后续关闭状态：G01 已由 PR #324 补齐；G02 的 OpenAI Chat／Anthropic Messages／Gemini／无状态 Responses 原生增量已由 PR #325–#328 合并，G04 的工具历史／结果增量已由 PR #329–#330 合并，本轮在 `ee774419` 上推进函数 Schema 兼容与拒绝边界，其余差异继续跟踪。本文核对仓库实现和测试，不代表真实厂商或 SDK 兼容认证。[架构文档](architecture.md)仍是目标设计，[实验性代理指南](../standalone/rust-proxy_CN.md)说明当前支持范围。
+审计基线：`d943c174`（2026-09-09，含 PR #323）。后续关闭状态：G01 已由 PR #324 补齐；G02 的 OpenAI Chat／Anthropic Messages／Gemini／无状态 Responses 原生增量已由 PR #325–#328 合并，G04 的工具历史／结果与 Schema 增量已由 PR #329–#331 合并，本轮在 `bf75bcfe` 上推进 G03 的用户图片输入转换，其余差异继续跟踪。本文核对仓库实现和测试，不代表真实厂商或 SDK 兼容认证。[架构文档](architecture.md)仍是目标设计，[实验性代理指南](../standalone/rust-proxy_CN.md)说明当前支持范围。
 
 **新文件配置 LLM 数据面已具备主要执行和生命周期机制，尚不能替换已发布 Server。** 同名能力不等于契约已迁移：模型 token bucket 不等于 API Key 请求窗口；存在 Responses 端点也不等于兼容 Codex 账号通道。
 
@@ -28,7 +28,7 @@
 |---|---|---|---|
 | G01 模型发现 | 已落地 | [旧模型列表](../../crates/nyro-core/src/proxy/handler.rs)的发现能力已由[新运行时](../../crates/nyro-llm/src/runtime.rs)承接；[模型列表测试](../../crates/nyro-llm/tests/models_runtime.rs)与[重载进程测试](../../tests/proxy_reload_smoke.py)覆盖过滤及代际变化。 | 按授权返回稳定排序的公开别名；匿名／绑定／无效／歧义凭证、空列表、成功／失败重载、密钥轮换和预算隔离已覆盖。无效密钥明确拒绝，不沿用旧公开列表回退；密钥到期仍由 G06 跟踪。 |
 | G02 同协议保真 | 部分 | [旧调度器](../../crates/nyro-core/src/proxy/dispatcher/mod.rs)按条件选择 Native 模式；[请求构建](../../crates/nyro-core/src/provider/common/pipeline.rs)和[非流式响应](../../crates/nyro-core/src/proxy/dispatcher/non_stream.rs)可跳过 IR 往返。[新运行时](../../crates/nyro-llm/src/runtime/native.rs)通过 Provider `native_chat: true` 保留匹配的 OpenAI Chat／无状态 Responses／Anthropic Messages／单候选 Gemini 请求、JSON 响应及 SSE 扩展；默认仍严格转换。 | OpenAI Chat／无状态 Responses／Anthropic Messages 和单候选 Gemini 的别名路由、usage、凭证隔离、重试兼容筛选、有界解析及流终态已覆盖；多候选／独立工具提示词计量和完整客户端仍待验收；Responses 已补无状态原生 mock 验证。Gemini 原生保留上游 modelVersion。只保留 JSON 字段，不承诺字节或任意 Header 透传；跨协议原始请求仍须通过来源严格 codec。 |
-| G03 推理、缓存与媒体语义 | 部分 | [旧转换测试](../../crates/nyro-core/tests/protocol_conversion.rs)覆盖 thinking／签名回放、`reasoning_content`、think-tag 归一化和 Gemini `fileData`。[新版限制](../standalone/rust-proxy_CN.md)的严格转换路径仍拒绝未支持的 Chat 内容块、缓存扩展和 Responses reasoning items；OpenAI Chat／Responses／Anthropic Messages／Gemini 原生模式只保留这些 JSON 字段，不新增跨协议语义映射。 | 为保留客户端建立字段／场景矩阵，保留可表达语义，明确拒绝不可表达的跨协议转换。OpenAI Chat 已有图片／音频类型字段，不能笼统说所有多模态都缺失；新增独立 Image/Audio/Video 操作另算范围。 |
+| G03 推理、缓存与媒体语义 | 部分 | [旧转换测试](../../crates/nyro-core/tests/protocol_conversion.rs)覆盖 thinking／签名回放、`reasoning_content`、think-tag 归一化和 Gemini `fileData`。[新版限制](../standalone/rust-proxy_CN.md)的严格转换路径仍拒绝未支持的 Chat 内容块、缓存扩展和 Responses reasoning items；OpenAI Chat／Responses／Anthropic Messages／Gemini 原生模式保留这些 JSON 字段；新[用户图片回归](../../crates/nyro-llm/tests/image_codec.rs)补充四格式内嵌 PNG／JPEG／WebP 及三格式 URL 引用转换，保持 detail／格式／角色边界。推理、缓存及其余媒体仍待处理。 | 为保留客户端建立字段／场景矩阵，保留可表达语义，明确拒绝不可表达的跨协议转换。OpenAI Chat 已有图片／音频类型字段，不能笼统说所有多模态都缺失；新增独立 Image/Audio/Video 操作另算范围。 |
 | G04 工具历史与 Schema 处理 | 部分／待取舍 | 旧转换测试包含合成调用、重复 ID 修复、丢弃中间文本／孤立调用、Gemini Schema 裁剪。新 [Anthropic](../../crates/nyro-llm/tests/anthropic_codec.rs)／[Gemini](../../crates/nyro-llm/tests/gemini_codec.rs) encoder 保留完整结果批次及后续文本，拒绝缺失／重复／交错批次；Anthropic 显式错误、空结果、[Responses](../../crates/nyro-llm/tests/responses_codec.rs) 文本块数组及 Gemini ID／顺序已补充。多块结果到 Gemini、跨协议错误标志映射和媒体结果明确拒绝。[Schema 回归](../../crates/nyro-llm/tests/tool_schema_codec.rs)已覆盖 JSON Schema 对象保留、Gemini 计数／类型／嵌套方言转换及 strict 目标筛选；不裁剪引用或约束。完整客户端／厂商验收仍待后续。 | 回放并行调用、交错文本、工具结果和 Schema，保留合法客户端历史；不自动迁移虚构调用或丢内容的处理。区分有意拒绝和兼容回退。 |
 | G05 Provider 通道与凭证 | 部分 | 旧版有[厂商适配](../../crates/nyro-core/src/provider/mod.rs)、[账号认证 driver](../../crates/nyro-core/src/auth/drivers/mod.rs)和 Vertex 服务账号支持。新 Provider 配置只有协议 kind、可选 OpenAI API、URL 和可选静态 API Key。 | 迁移必要端点、Header 和凭证行为，不向 driver 传递 Gateway 或数据库实体。账号授权、刷新、持久化归控制面；driver 消费已解析凭证。详见下方清单。 |
 | G06 API Key 生命周期 | 部分 | [旧授权](../../crates/nyro-core/src/proxy/dispatcher/auth.rs)检查启用状态、过期时间和模型绑定。新 `ApiKey` 只有 `id`、`secret`；可以重载移除密钥，但没有到期自动失效。 | 对新准入执行到期检查；发布配置保留绑定及禁用语义，验证时间边界和重载；明确已准入请求保持原代际。模型发现与调用授权保持一致。 |
@@ -76,7 +76,7 @@
 | 4 | G10–G12：最小 `nyro serve`，先 SQLite 和一条管理到发布路径，再补 Postgres 等价与其余管理能力。 | 持久化 → 校验 → 发布 → 新请求使用快照；失败保留活动代际；重启／数据兼容；WebUI/API 与观测一致。可与兼容工作并行推进，单独完成不代表可发布替换。 |
 | 5 | G11/G13：部署、工具、发布切换。 | 文件／控制面等价，保留 CLI、录制客户端矩阵、支持平台构建、迁移／恢复说明全部过关后移除旧入口。 |
 
-步骤 1 已完成；步骤 2 已完成 16 份录制样本分类、OpenAI Chat／Anthropic Messages 原生增量及单候选 Gemini mock 验证，无状态 Responses 原生 mock 验证也已完成；PR #329 补充四种入口到 Anthropic 的完整并行工具结果历史转换，PR #330 补充工具错误、空／分块文本结果及 Gemini ID／批次语义，本轮补充函数 Schema 保留、转换和拒绝边界；跨协议推理及真实会话仍继续跟踪。原生保真和密钥限制语义仍是发布阻塞项；后续每一步可能需要多份聚焦 PR。
+步骤 1 已完成；步骤 2 已完成 16 份录制样本分类、OpenAI Chat／Anthropic Messages 原生增量及单候选 Gemini mock 验证，无状态 Responses 原生 mock 验证也已完成；PR #329 补充四种入口到 Anthropic 的完整并行工具结果历史转换，PR #330 补充工具错误、空／分块文本结果及 Gemini ID／批次语义，PR #331 补充函数 Schema 保留、转换和拒绝边界；本轮补充用户图片输入，跨协议推理、缓存和真实会话仍继续跟踪。原生保真和密钥限制语义仍是发布阻塞项；后续每一步可能需要多份聚焦 PR。
 
 复用[现有录制 fixture](../../tests/e2e/fixtures)和[旧回放矩阵](../../tests/e2e/proxy/test_protocol_matrix.py)作为输入，不能把它们当作新代理已通过的证据。旧 harness 依赖旧配置／工具流程，部分断言仅检查文本锚点／字段名；新断言必须核对有效内容顺序、工具 ID／参数、用量、凭证隔离和终态。端到端认证需记录客户端版本，本地 mock 不代表当前 SDK／厂商兼容。
 
@@ -298,3 +298,33 @@ python3 tests/proxy_reload_smoke.py
 293 项 Rust 测试（本轮新增 7 项）、Clippy、非桌面 workspace 检查、构建和五组进程回归通过。16 份录制样本的原生精确回放及默认严格／显式 false 分类通过；格式、diff 和 97 个文档相对链接检查通过。`docs/superpowers/` 继续忽略，不进入 Git。
 
 G04 的当前文本／客户端函数子集已具备历史和 Schema 回归证据；仍不据此宣称全部厂商／客户端兼容完成。媒体工具结果、不可保留的顺序、含糊 Schema 映射继续明确拒绝，完整客户端验收与 G02–G03 协同推进。没有使用真实厂商密钥，没有新增 crate、依赖或内核职责。
+
+## 15. G03 用户图片输入增量
+
+核对旧[推理／媒体转换测试](../../crates/nyro-core/tests/protocol_conversion.rs)及 16 份现有录制样本：旧测试包括 thinking／签名、reasoning_content、think-tag 处理和 Gemini fileData；录制请求不包含图片，不能据此证明图片转换兼容。推理签名和缓存控制需要各自的语义边界，本轮先复用既有图片 IR 补充有明确协议对应关系的用户输入。
+
+- 四种入口／目标支持 PNG、JPEG、WebP 内嵌图片；OpenAI Chat、Responses、Anthropic 另支持 GIF 及 HTTP(S) 图片引用。Gemini 不接受 GIF 或远程 URL 转换，不下载内容或合成 fileData。
+- 保留图文顺序、URL、声明 MIME 与 base64 数据。detail 的 auto／缺省使用目标默认行为，low／high／original 只在 OpenAI Chat／Responses 间保留；不猜测与 Gemini mediaResolution 或 Anthropic 变换选项的对应关系。
+- 仅允许 user 消息图片。工具结果、system／developer／assistant、厂商文件 ID、fileData、HEIC／HEIF 和缓存等扩展仍明确拒绝。新 wire 图片类型不放宽 Anthropic／Gemini JSON 或流式图片输出；本轮不新增图片生成／输出转换。
+- `nyro-protocol` 补充基础 wire 形状，`nyro-llm` 复用 `ContentPart::ImageUrl` 并增加私有图片来源辅助逻辑，直接依赖仓库已锁定的 base64 0.22 版本。公共 IR、内核、Provider 和原生转发没有新增职责。不校验像素、MIME 与实际字节的一致性或模型能力，也不下载／转码；请求体限制沿用现有运行时边界。
+
+新增 6 项 [codec 回归](../../crates/nyro-llm/tests/image_codec.rs)，其中 4 项先复现图片拒绝及校验缺失；另覆盖新增 wire 变体不能被误当作生成文本、以及 MIME／GIF 目标边界。新增 2 项[运行时回归](../../crates/nyro-llm/tests/responses_runtime.rs)，覆盖 56 组内嵌／URL 图片 JSON／SSE 转换与拒绝、32 组 detail 保留／目标筛选，核对实际上游内容和许可释放。旧“所有图片均拒绝”的断言调整为仍不支持的文件 ID，工具图片拒绝继续保留。独立审查未发现阻塞问题。
+
+实际执行：
+
+```sh
+cargo test -p nyro-llm --test image_codec --test responses_runtime --offline
+cargo test -p nyro-protocol -p nyro-llm -p nyro-config -p nyro --offline
+cargo clippy -p nyro-protocol -p nyro-llm -p nyro-config -p nyro --all-targets --offline -- -D warnings
+cargo check --workspace --exclude nyro-desktop --offline
+cargo build -p nyro --offline
+python3 tests/proxy_native_replay.py
+python3 tests/proxy_gemini_native_smoke.py
+python3 tests/proxy_responses_native_smoke.py
+python3 tests/proxy_smoke.py
+python3 tests/proxy_reload_smoke.py
+```
+
+301 项 Rust 测试（本轮新增 8 项）、Clippy、非桌面 workspace 检查、构建和五组进程回归通过。16 份录制样本的原生精确回放与默认严格／显式 false 分类通过；格式、diff 和 101 个文档相对链接检查通过。`docs/superpowers/` 继续忽略，不进入 Git。
+
+G03 仍为部分完成：推理／签名、缓存控制及计量、其余 Chat 媒体和完整客户端会话仍待后续。这里使用本地 mock 与一张 1×1 PNG，没有使用真实厂商密钥，不代表视觉推理质量或厂商认证。整体迁移完成后删除本文，不做归档。

--- a/docs/standalone/rust-proxy.md
+++ b/docs/standalone/rust-proxy.md
@@ -221,9 +221,26 @@ curl http://127.0.0.1:19530/v1beta/models/gemini-default:generateContent \
 
 An alias selects the configured upstream independently of the client protocol. An Anthropic backend is eligible only with an explicit token limit (`max_tokens`, or a representable equivalent); Nyro does not invent one. Native clients routed to an OpenAI stream request upstream usage automatically. OpenAI Chat Completions clients receive usage only when `stream_options.include_usage` is true.
 
-The strict conversion path is an experimental text/function Chat subset. Its codecs reject image/audio/video, thinking/signature blocks, unrepresentable content ordering, multiple candidates, and unsupported vendor options or diagnostics. Examples include Anthropic caching/usage details and matched stop-sequence responses; Gemini safety settings, safety ratings, grounding/citations, prompt feedback and structured-output settings; and OpenAI response fingerprint/service-tier/logprob metadata when it cannot be represented by a native output. Supported fields in one protocol are not automatically representable in another: unsupported requests fail before dispatch; unsupported upstream responses fail with `502` or a terminated SSE stream. Native Embedding APIs and full SDK/vendor feature parity remain future work.
+The strict conversion path is an experimental Chat subset for text, user image inputs and client functions. Cross-protocol audio/video, thinking/signature blocks, unrepresentable content ordering, multiple candidates, and unsupported vendor options or diagnostics remain unsupported. Examples include Anthropic caching/usage details and matched stop-sequence responses; Gemini safety settings, safety ratings, grounding/citations, prompt feedback and structured-output settings; and OpenAI response fingerprint/service-tier/logprob metadata when it cannot be represented by a native output. Supported fields in one protocol are not automatically representable in another: unsupported requests fail before dispatch; unsupported upstream responses fail with `502` or a terminated SSE stream. Native Embedding APIs and full SDK/vendor feature parity remain future work.
 
 Protocol reference: [Anthropic streaming](https://platform.claude.com/docs/en/build-with-claude/streaming), [Gemini generateContent](https://ai.google.dev/api/generate-content). Local matrix regression: `cargo test -p nyro-llm --test protocol_matrix`.
+
+## User image inputs
+
+User-message images reuse the existing Chat IR; this does not introduce an image-generation workload. Supported strict conversions preserve image/text order, URL strings, declared MIME types and base64 content:
+
+| Input form | Eligible destinations |
+|---|---|
+| OpenAI Chat `image_url` data URI, Responses `input_image.image_url` data URI, Anthropic `image` base64 source, Gemini `inlineData` | PNG/JPEG/WebP across all four formats. |
+| GIF data URI or Anthropic base64 source | OpenAI Chat, Responses and Anthropic; Gemini is ineligible. |
+| HTTP(S) image URL in OpenAI Chat, Responses or Anthropic | These three formats; Gemini is ineligible because conversion does not download the image or fabricate `fileData`. |
+| OpenAI Chat/Responses `detail` | `auto` or omitted can use all otherwise eligible destinations. `low`, `high` and `original` are retained only for OpenAI Chat/Responses; they make Anthropic/Gemini ineligible. |
+
+Only user messages gain image conversion. System/developer/assistant images, tool-result images, vendor file IDs, Gemini `fileData`, HEIC/HEIF, image-specific caching/transformations/resolution extensions and image output conversion are outside this increment. Unsupported source shapes or non-user images fail strict decoding; incompatible targets are excluded before dispatch. If none remain, the request returns `400`. Opt-in matching native forwarding keeps its existing contract.
+
+Nyro checks source shape, HTTP(S) URL syntax, the supported MIME label and nonempty standard base64 encoding. It does not fetch URLs, decode pixels, verify bytes against the MIME label, resize, transcode or prove model vision support. Existing request-body limits still apply; the configured upstream validates image contents and model-specific limits. The stricter source/role checks also apply to direct strict OpenAI Chat codec use.
+
+References: [OpenAI image inputs and detail](https://developers.openai.com/api/docs/guides/images-vision), [Anthropic image sources](https://platform.claude.com/docs/en/build-with-claude/vision), [Gemini inline images](https://ai.google.dev/gemini-api/docs/image-understanding). Local regressions: `cargo test -p nyro-llm --test image_codec --test responses_runtime`. These use local mock upstreams, not vendor vision certification.
 
 ## Strict tool history and results
 
@@ -345,7 +362,7 @@ curl http://127.0.0.1:19530/v1/responses \
 
 Function results accept a string `function_call_output.output` or an array containing only `input_text` blocks, including an empty array. Conversion preserves block boundaries rather than concatenating them. Multiple result blocks are incompatible with a strict Gemini destination; media and other result block types are rejected.
 
-This strict conversion path is stateless: outbound Responses always sets `store:false`, and Responses ingress translated to Chat Completions also explicitly disables storage. Server conversation state (`conversation`, `previous_response_id`), item references, `store:true`, `background:true`, hosted tools, reasoning items, media, and response retrieval/deletion/cancellation are unsupported. Meaningful options or output items that the current Chat IR cannot preserve are rejected. Responses envelope echoes and item IDs are normalized; exact upstream IDs and request echoes are not preserved. Function `call_id`, content order, finish status, and representable usage remain part of the conversion contract.
+This strict conversion path is stateless: outbound Responses always sets `store:false`, and Responses ingress translated to Chat Completions also explicitly disables storage. Server conversation state (`conversation`, `previous_response_id`), item references, `store:true`, `background:true`, hosted tools, reasoning items, media outside the user-image subset, and response retrieval/deletion/cancellation are unsupported. Meaningful options or output items that the current Chat IR cannot preserve are rejected. Responses envelope echoes and item IDs are normalized; exact upstream IDs and request echoes are not preserved. Function `call_id`, content order, finish status, and representable usage remain part of the conversion contract.
 
 SSE uses named Responses lifecycle events, stable item IDs, ordered sequence numbers, and a full terminal snapshot, without a `[DONE]` marker. Token-limit/content-filter endings produce `response.incomplete`. Failed, contradictory, malformed, or truncated upstream streams terminate without a fabricated successful completion. Strict Responses upstream streaming disables obfuscation. This subset does not establish full Responses SDK or Codex CLI compatibility.
 

--- a/docs/standalone/rust-proxy_CN.md
+++ b/docs/standalone/rust-proxy_CN.md
@@ -221,9 +221,26 @@ curl http://127.0.0.1:19530/v1beta/models/gemini-default:generateContent \
 
 模型别名选择上游，与客户端协议独立。Anthropic backend 只有在请求显式提供 token 上限时才参与选择（`max_tokens` 或能转换的等价字段），Nyro 不自行设置默认值。原生客户端使用 OpenAI 流式上游时会自动请求用量；OpenAI Chat Completions 客户端只有设置 `stream_options.include_usage: true` 才接收用量。
 
-严格转换路径是实验性的文本／函数 Chat 子集，其 codec 拒绝图片、音频、视频、thinking／签名块、无法保留的内容顺序、多候选以及不支持的厂商选项或诊断字段。例如 Anthropic 缓存／用量扩展和命中 stop sequence 的响应；Gemini 安全设置、safety ratings、grounding／引用、prompt feedback 和结构化输出设置；以及无法在原生输出中表示的 OpenAI fingerprint／service-tier／logprob 元数据。某协议已支持的字段不一定能转换到另一协议：不可转换的请求在发往上游前失败；不可转换的上游响应返回 `502` 或终止 SSE 流。原生 Embedding API 和完整 SDK／厂商功能对齐属于后续工作。
+严格转换路径是实验性的文本／用户图片／客户端函数 Chat 子集，仍不支持跨协议音频／视频、thinking／签名块、无法保留的内容顺序、多候选以及不支持的厂商选项或诊断字段。例如 Anthropic 缓存／用量扩展和命中 stop sequence 的响应；Gemini 安全设置、safety ratings、grounding／引用、prompt feedback 和结构化输出设置；以及无法在原生输出中表示的 OpenAI fingerprint／service-tier／logprob 元数据。某协议已支持的字段不一定能转换到另一协议：不可转换的请求在发往上游前失败；不可转换的上游响应返回 `502` 或终止 SSE 流。原生 Embedding API 和完整 SDK／厂商功能对齐属于后续工作。
 
 协议参考：[Anthropic streaming](https://platform.claude.com/docs/en/build-with-claude/streaming)、[Gemini generateContent](https://ai.google.dev/api/generate-content)。本地矩阵回归：`cargo test -p nyro-llm --test protocol_matrix`。
+
+## 用户图片输入
+
+用户消息中的图片复用现有 Chat IR，不新增图片生成工作负载。严格转换保留图文顺序、URL 字符串、声明的 MIME 类型及 base64 内容：
+
+| 输入形式 | 可选目标 |
+|---|---|
+| OpenAI Chat `image_url` data URI、Responses `input_image.image_url` data URI、Anthropic `image` base64 source、Gemini `inlineData` | PNG／JPEG／WebP 可在四种格式间转换。 |
+| GIF data URI 或 Anthropic base64 source | OpenAI Chat、Responses、Anthropic；Gemini 不作为候选。 |
+| OpenAI Chat、Responses 或 Anthropic 的 HTTP(S) 图片 URL | 这三种格式；Gemini 不作为候选，不下载图片或虚构 `fileData`。 |
+| OpenAI Chat／Responses `detail` | `auto` 或省略时可使用其他条件满足的目标；`low`、`high`、`original` 仅在 OpenAI Chat／Responses 间保留，使 Anthropic／Gemini 不再符合条件。 |
+
+本轮仅增加 user 消息图片转换。system／developer／assistant 图片、工具结果图片、厂商文件 ID、Gemini `fileData`、HEIC／HEIF、图片缓存／变换／分辨率扩展及图片输出转换不属于本轮范围。未支持的来源形状或非 user 图片在严格解码时拒绝；无法表达的目标在发送前排除，没有候选时返回 `400`。匹配的显式原生转发保持已有契约。
+
+Nyro 校验来源形状、HTTP(S) URL 语法、支持的 MIME 标签和非空标准 base64 编码；不下载 URL、不解码像素、不验证实际字节与 MIME 是否一致、不缩放或转码，也不证明模型支持视觉输入。现有请求体大小限制继续生效；图片内容和模型特定限制由所配置的上游校验。更严格的来源／角色检查也适用于直接调用严格 OpenAI Chat codec。
+
+参考：[OpenAI 图片输入与 detail](https://developers.openai.com/api/docs/guides/images-vision)、[Anthropic 图片来源](https://platform.claude.com/docs/en/build-with-claude/vision)、[Gemini 内嵌图片](https://ai.google.dev/gemini-api/docs/image-understanding)。本地回归：`cargo test -p nyro-llm --test image_codec --test responses_runtime`。测试使用本地 mock 上游，不是厂商视觉能力认证。
 
 ## 严格转换的工具历史与结果
 
@@ -345,7 +362,7 @@ curl http://127.0.0.1:19530/v1/responses \
 
 函数结果 `function_call_output.output` 接受字符串或仅包含 `input_text` 块的数组，包括空数组。转换保留块边界，不拼接文本。多个结果块无法严格转换到 Gemini 目标；媒体及其他结果块类型被拒绝。
 
-此严格转换路径仅支持无状态调用：发往 Responses 上游时固定 `store:false`；Responses 入口转为 Chat Completions 上游时也显式禁用存储。暂不支持服务端会话（`conversation`、`previous_response_id`）、item 引用、`store:true`、`background:true`、内置工具、reasoning items、多媒体及响应查询／删除／取消。当前 Chat IR 无法保留的有效选项或输出项会被明确拒绝。Responses 外层回显字段和 item ID 会归一化，不保证保留上游原始 ID 或精确请求回显；函数 `call_id`、内容顺序、终止状态和可表达的用量属于转换契约。
+此严格转换路径仅支持无状态调用：发往 Responses 上游时固定 `store:false`；Responses 入口转为 Chat Completions 上游时也显式禁用存储。暂不支持服务端会话（`conversation`、`previous_response_id`）、item 引用、`store:true`、`background:true`、内置工具、reasoning items、用户图片子集以外的媒体及响应查询／删除／取消。当前 Chat IR 无法保留的有效选项或输出项会被明确拒绝。Responses 外层回显字段和 item ID 会归一化，不保证保留上游原始 ID 或精确请求回显；函数 `call_id`、内容顺序、终止状态和可表达的用量属于转换契约。
 
 SSE 使用 Responses 命名生命周期事件、稳定 item ID、递增序号和完整终态快照，不输出 `[DONE]`。token 上限／内容过滤结束会映射成 `response.incomplete`；上游失败、内容矛盾、格式错误或断流不会伪造成功终态。严格 Responses 上游流关闭 obfuscation。此子集不代表已经完整兼容 Responses SDK 或 Codex CLI。
 


### PR DESCRIPTION
Preserve image data and content order across Chat codecs. Reject unsupported sources, roles and destination detail settings without fetching or transcoding images.

Strict OpenAI Chat also validates image sources and user-message roles. Update migration progress and bilingual proxy documentation.