### PR TITLE
feat(llm): support current cache controls

### DIFF
--- a/crates/nyro-llm/src/codec/openai.rs
+++ b/crates/nyro-llm/src/codec/openai.rs
@@ -1,5 +1,6 @@
 //! Explicit OpenAI wire ↔ typed workload conversion; unsupported fields are rejected.
 pub use super::CodecError;
+pub(crate) mod cache;
 pub mod responses;
 use crate::ir::*;
 use nyro_protocol::openai::{chat, embedding, stream};
@@ -53,6 +54,8 @@ pub fn decode_chat(value: Value) -> Result<ChatRequest, CodecError> {
             metadata: wire.metadata,
             safety_identifier: wire.safety_identifier,
             prompt_cache_key: wire.prompt_cache_key,
+            prompt_cache_retention: wire.prompt_cache_retention,
+            prompt_cache_options: wire.prompt_cache_options,
         }),
     };
     validate_chat(&request)?;
@@ -157,6 +160,8 @@ pub fn encode_chat(request: &ChatRequest) -> Result<Value, CodecError> {
         metadata: request.openai.metadata.clone(),
         safety_identifier: request.openai.safety_identifier.clone(),
         prompt_cache_key: request.openai.prompt_cache_key.clone(),
+        prompt_cache_retention: request.openai.prompt_cache_retention,
+        prompt_cache_options: request.openai.prompt_cache_options.clone(),
     };
     Ok(serde_json::to_value(wire)?)
 }
@@ -185,7 +190,7 @@ pub fn encode_embedding(request: &EmbeddingRequest) -> Result<Value, CodecError>
     Ok(serde_json::to_value(wire)?)
 }
 pub fn decode_chat_response(value: Value) -> Result<ChatResponse, CodecError> {
-    let wire: chat::Response = serde_json::from_value(value)?;
+    let mut wire: chat::Response = serde_json::from_value(value)?;
     if wire.object != "chat.completion" {
         return Err(invalid("expected chat.completion object"));
     }
@@ -196,10 +201,16 @@ pub fn decode_chat_response(value: Value) -> Result<ChatResponse, CodecError> {
     {
         return Err(invalid("response messages require assistant role"));
     }
-    convert(wire)
+    let usage = wire.usage.take().map(cache::decode).transpose()?;
+    let mut response: ChatResponse = convert(wire)?;
+    response.usage = usage;
+    Ok(response)
 }
 pub fn encode_chat_response(response: &ChatResponse) -> Result<Value, CodecError> {
-    let wire: chat::Response = convert(response)?;
+    let mut plain = response.clone();
+    let usage = plain.usage.take().as_ref().map(cache::encode).transpose()?;
+    let mut wire: chat::Response = convert(plain)?;
+    wire.usage = usage;
     Ok(serde_json::to_value(wire)?)
 }
 pub fn decode_embedding_response(value: Value) -> Result<EmbeddingResponse, CodecError> {
@@ -217,17 +228,23 @@ pub fn decode_chat_event(data: &str) -> Result<ChatEvent, CodecError> {
     if data.trim() == "[DONE]" {
         return Ok(ChatEvent::Done);
     }
-    let wire: stream::Chunk = serde_json::from_str(data)?;
+    let mut wire: stream::Chunk = serde_json::from_str(data)?;
     if wire.object != "chat.completion.chunk" {
         return Err(invalid("expected chat.completion.chunk object"));
     }
-    Ok(ChatEvent::Chunk(Box::new(convert(wire)?)))
+    let usage = wire.usage.take().map(cache::decode).transpose()?;
+    let mut chunk: ChatChunk = convert(wire)?;
+    chunk.usage = usage;
+    Ok(ChatEvent::Chunk(Box::new(chunk)))
 }
 pub fn encode_chat_event(event: &ChatEvent, public_model: &str) -> Result<String, CodecError> {
     match event {
         ChatEvent::Done => Ok("data: [DONE]\n\n".into()),
         ChatEvent::Chunk(chunk) => {
-            let mut wire: stream::Chunk = convert(chunk)?;
+            let mut plain = (**chunk).clone();
+            let usage = plain.usage.take().as_ref().map(cache::encode).transpose()?;
+            let mut wire: stream::Chunk = convert(plain)?;
+            wire.usage = usage;
             wire.model = public_model.into();
             Ok(format!("data: {}\n\n", serde_json::to_string(&wire)?))
         }

--- a/crates/nyro-llm/src/codec/openai/cache.rs
+++ b/crates/nyro-llm/src/codec/openai/cache.rs
@@ -1,0 +1,65 @@
+//! OpenAI reports cache reads/writes within its inclusive input count.
+use super::{CodecError, convert, invalid};
+use crate::ir::{CacheCreationUsage, Usage};
+use nyro_protocol::openai::chat;
+
+pub(super) fn decode(mut wire: chat::Usage) -> Result<Usage, CodecError> {
+    let written = wire
+        .prompt_tokens_details
+        .as_mut()
+        .and_then(|d| d.cache_write_tokens.take());
+    let mut usage: Usage = convert(wire)?;
+    usage.cache_creation = written.map(|input_tokens| {
+        Box::new(CacheCreationUsage {
+            input_tokens,
+            ephemeral_5m_input_tokens: None,
+            ephemeral_1h_input_tokens: None,
+        })
+    });
+    validate(&usage)?;
+    usage.cache_creation = usage.cache_creation.filter(|c| c.input_tokens != 0);
+    Ok(usage)
+}
+
+pub(crate) fn validate(usage: &Usage) -> Result<(), CodecError> {
+    // Keep the existing observation/quota policy for legacy usage without
+    // writes; this codec validates the newly supported write metadata.
+    let Some(creation) = &usage.cache_creation else {
+        return Ok(());
+    };
+    let read = usage
+        .prompt_tokens_details
+        .as_ref()
+        .and_then(|d| d.cached_tokens)
+        .unwrap_or(0);
+    let written = creation.input_tokens;
+    if usage.prompt_tokens.checked_add(usage.completion_tokens) != Some(usage.total_tokens)
+        || read
+            .checked_add(written)
+            .is_none_or(|n| n > usage.prompt_tokens)
+        || creation.ephemeral_5m_input_tokens.is_some()
+        || creation.ephemeral_1h_input_tokens.is_some()
+    {
+        return Err(invalid(
+            "invalid or unrepresentable OpenAI cache/token usage",
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn encode(usage: &Usage) -> Result<chat::Usage, CodecError> {
+    validate(usage)?;
+    let mut plain = usage.clone();
+    let creation = plain.cache_creation.take();
+    let mut wire: chat::Usage = convert(plain)?;
+    if let Some(creation) = creation {
+        wire.prompt_tokens_details
+            .get_or_insert(chat::PromptTokensDetails {
+                cached_tokens: None,
+                audio_tokens: None,
+                cache_write_tokens: None,
+            })
+            .cache_write_tokens = Some(creation.input_tokens);
+    }
+    Ok(wire)
+}

--- a/crates/nyro-llm/src/codec/openai/responses.rs
+++ b/crates/nyro-llm/src/codec/openai/responses.rs
@@ -223,6 +223,8 @@ pub fn decode_chat(value: Value) -> Result<ChatRequest, CodecError> {
             user: r.user,
             safety_identifier: r.safety_identifier,
             prompt_cache_key: r.prompt_cache_key,
+            prompt_cache_retention: r.prompt_cache_retention,
+            prompt_cache_options: r.prompt_cache_options,
             ..Default::default()
         }),
     };
@@ -351,6 +353,8 @@ pub fn encode_chat(r: &ChatRequest) -> Result<Value, CodecError> {
         ("user", json!(o.user)),
         ("safety_identifier", json!(o.safety_identifier)),
         ("prompt_cache_key", json!(o.prompt_cache_key)),
+        ("prompt_cache_retention", json!(o.prompt_cache_retention)),
+        ("prompt_cache_options", json!(o.prompt_cache_options)),
     ] {
         if !value.is_null() {
             map.insert(key.into(), value);
@@ -443,6 +447,13 @@ fn validate_envelope(r: &wire::Response) -> Result<(), CodecError> {
                 v.is_null() || v.as_u64().is_some()
             }
             "parallel_tool_calls" => v.is_null() || v.is_boolean(),
+            "prompt_cache_options" => {
+                v.is_null()
+                    || serde_json::from_value::<nyro_protocol::openai::PromptCacheOptions>(
+                        v.clone(),
+                    )
+                    .is_ok()
+            }
             "instructions"
             | "service_tier"
             | "user"
@@ -516,11 +527,22 @@ fn decode_usage(u: wire::Usage) -> Result<Usage, CodecError> {
     {
         return Err(bad("invalid Responses token usage"));
     }
-    Ok(Usage {
+    let usage = Usage {
         prompt_tokens: u.input_tokens,
         completion_tokens: u.output_tokens,
         total_tokens: u.total_tokens,
-        cache_creation: None,
+        cache_creation: u
+            .input_tokens_details
+            .as_ref()
+            .and_then(|d| d.cache_write_tokens)
+            .filter(|n| *n != 0)
+            .map(|input_tokens| {
+                Box::new(CacheCreationUsage {
+                    input_tokens,
+                    ephemeral_5m_input_tokens: None,
+                    ephemeral_1h_input_tokens: None,
+                })
+            }),
         prompt_tokens_details: u
             .input_tokens_details
             .filter(|d| d.cached_tokens != 0)
@@ -537,12 +559,12 @@ fn decode_usage(u: wire::Usage) -> Result<Usage, CodecError> {
                 accepted_prediction_tokens: None,
                 rejected_prediction_tokens: None,
             }),
-    })
+    };
+    super::cache::validate(&usage)?;
+    Ok(usage)
 }
 fn encode_usage(u: &Usage) -> Result<Value, CodecError> {
-    if u.cache_creation.is_some() {
-        return Err(bad("Responses cannot represent cache creation usage"));
-    }
+    super::cache::validate(u)?;
     if u.prompt_tokens.checked_add(u.completion_tokens) != Some(u.total_tokens)
         || u.prompt_tokens_details
             .as_ref()
@@ -571,11 +593,13 @@ fn encode_usage(u: &Usage) -> Result<Value, CodecError> {
     {
         return Err(bad("Responses cannot represent audio/prediction usage"));
     }
-    Ok(
-        json!({"input_tokens":u.prompt_tokens,"output_tokens":u.completion_tokens,"total_tokens":u.total_tokens,
+    let mut value = json!({"input_tokens":u.prompt_tokens,"output_tokens":u.completion_tokens,"total_tokens":u.total_tokens,
         "input_tokens_details":{"cached_tokens":u.prompt_tokens_details.as_ref().and_then(|d|d.cached_tokens).unwrap_or(0)},
-        "output_tokens_details":{"reasoning_tokens":u.completion_tokens_details.as_ref().and_then(|d|d.reasoning_tokens).unwrap_or(0)}}),
-    )
+        "output_tokens_details":{"reasoning_tokens":u.completion_tokens_details.as_ref().and_then(|d|d.reasoning_tokens).unwrap_or(0)}});
+    if let Some(creation) = &u.cache_creation {
+        value["input_tokens_details"]["cache_write_tokens"] = json!(creation.input_tokens);
+    }
+    Ok(value)
 }
 fn finish_reason(r: &wire::Response) -> Result<&'static str, CodecError> {
     match r.status.as_str() {

--- a/crates/nyro-llm/src/ir/mod.rs
+++ b/crates/nyro-llm/src/ir/mod.rs
@@ -141,6 +141,10 @@ pub struct OpenAiOptions {
     pub safety_identifier: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prompt_cache_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_cache_retention: Option<nyro_protocol::openai::PromptCacheRetention>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_cache_options: Option<nyro_protocol::openai::PromptCacheOptions>,
 }
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ChatRequest {

--- a/crates/nyro-llm/src/runtime/native.rs
+++ b/crates/nyro-llm/src/runtime/native.rs
@@ -14,6 +14,21 @@ mod responses;
 use nyro_protocol::framing::Event;
 use serde_json::{Value, json};
 
+// Preserve native detail extensions, but validate the known disjoint cache
+// subsets when the upstream reports a write count.
+fn validate_cache_write(details: &Value, input: u64) -> Result<(), Failure> {
+    if let Some(written) = details.get("cache_write_tokens") {
+        let written = written.as_u64().ok_or_else(Failure::upstream)?;
+        let read = details
+            .get("cached_tokens")
+            .map_or(Ok(0), |v| v.as_u64().ok_or_else(Failure::upstream))?;
+        if read.checked_add(written).is_none_or(|n| n > input) {
+            return Err(Failure::upstream());
+        }
+    }
+    Ok(())
+}
+
 pub(super) enum Input {
     Typed(Request),
     Native(NativeRequest),

--- a/crates/nyro-llm/src/runtime/native/openai.rs
+++ b/crates/nyro-llm/src/runtime/native/openai.rs
@@ -54,6 +54,12 @@ pub(super) fn response(
         None
     } else {
         let usage = &value["usage"];
+        super::validate_cache_write(
+            &usage["prompt_tokens_details"],
+            usage["prompt_tokens"]
+                .as_u64()
+                .ok_or_else(Failure::upstream)?,
+        )?;
         Some(Usage {
             prompt_tokens: usage["prompt_tokens"]
                 .as_u64()

--- a/crates/nyro-llm/src/runtime/native/responses.rs
+++ b/crates/nyro-llm/src/runtime/native/responses.rs
@@ -103,6 +103,7 @@ fn usage(value: &Value) -> Result<Option<Usage>, Failure> {
     if input.checked_add(output) != Some(total) {
         return Err(Failure::upstream());
     }
+    super::validate_cache_write(&value["input_tokens_details"], input)?;
     for (details, field, bound) in [
         ("input_tokens_details", "cached_tokens", input),
         ("output_tokens_details", "reasoning_tokens", output),

--- a/crates/nyro-llm/src/runtime/stream.rs
+++ b/crates/nyro-llm/src/runtime/stream.rs
@@ -55,14 +55,9 @@ impl Encode {
                 include_usage,
             } => {
                 if let ChatEvent::Chunk(chunk) = event
-                    && chunk
-                        .usage
-                        .as_ref()
-                        .is_some_and(|u| u.cache_creation.is_some())
+                    && let Some(usage) = &chunk.usage
                 {
-                    return Err(CodecError(
-                        "OpenAI Chat cannot represent cache creation usage".into(),
-                    ));
+                    openai::cache::validate(usage)?;
                 }
                 if !*include_usage && let ChatEvent::Chunk(chunk) = event {
                     if chunk.choices.is_empty() {

--- a/crates/nyro-llm/tests/cache_control_codec.rs
+++ b/crates/nyro-llm/tests/cache_control_codec.rs
@@ -1,0 +1,209 @@
+use nyro_llm::codec::{anthropic, gemini, openai};
+use serde_json::{Value, json};
+
+fn request(responses: bool) -> Value {
+    if responses {
+        json!({"model":"public","input":"Hello","max_output_tokens":32})
+    } else {
+        json!({"model":"public","messages":[{"role":"user","content":"Hello"}],"max_tokens":32})
+    }
+}
+
+#[test]
+fn openai_cache_retention_and_key_survive_both_api_formats() {
+    for responses in [false, true] {
+        for retention in ["in_memory", "24h"] {
+            let mut body = request(responses);
+            body["prompt_cache_retention"] = json!(retention);
+            body["prompt_cache_key"] = json!("tenant:conversation");
+            let r = if responses {
+                openai::responses::decode_chat(body)
+            } else {
+                openai::decode_chat(body)
+            }
+            .unwrap();
+            for encoded in [openai::encode_chat(&r), openai::responses::encode_chat(&r)] {
+                let encoded = encoded.unwrap();
+                assert_eq!(encoded["prompt_cache_retention"], retention);
+                assert_eq!(encoded["prompt_cache_key"], "tenant:conversation");
+            }
+            assert!(anthropic::encode_chat(&r).is_err());
+            assert!(gemini::encode_chat(&r).is_err());
+            // Retention alone must also make incompatible targets ineligible.
+            let mut r = r;
+            r.openai.prompt_cache_key = None;
+            assert!(anthropic::encode_chat(&r).is_err());
+            assert!(gemini::encode_chat(&r).is_err());
+        }
+    }
+}
+
+#[test]
+fn cache_retention_absence_null_and_invalid_values_are_distinct() {
+    for responses in [false, true] {
+        for value in [
+            None,
+            Some(Value::Null),
+            Some(json!("1h")),
+            Some(json!("")),
+            Some(json!(24)),
+            Some(json!({"ttl":"24h"})),
+        ] {
+            let mut body = request(responses);
+            if let Some(value) = &value {
+                body["prompt_cache_retention"] = value.clone();
+            }
+            let decoded = if responses {
+                openai::responses::decode_chat(body)
+            } else {
+                openai::decode_chat(body)
+            };
+            if value.as_ref().is_none_or(Value::is_null) {
+                let r = decoded.unwrap();
+                assert!(
+                    openai::encode_chat(&r)
+                        .unwrap()
+                        .get("prompt_cache_retention")
+                        .is_none()
+                );
+                assert!(
+                    openai::responses::encode_chat(&r)
+                        .unwrap()
+                        .get("prompt_cache_retention")
+                        .is_none()
+                );
+                assert!(anthropic::encode_chat(&r).is_ok());
+                assert!(gemini::encode_chat(&r).is_ok());
+            } else {
+                assert!(decoded.is_err(), "{responses}: {value:?}");
+            }
+        }
+    }
+}
+
+#[test]
+fn vendor_cache_controls_are_not_silently_converted() {
+    let mut anthropic =
+        json!({"model":"public","messages":[{"role":"user","content":"Hello"}],"max_tokens":32});
+    anthropic["cache_control"] = json!({"type":"ephemeral","ttl":"1h"});
+    assert!(anthropic::decode_chat(anthropic).is_err());
+    assert!(gemini::decode_chat(json!({"contents":[{"role":"user","parts":[{"text":"Hello"}]}],"cachedContent":"cachedContents/existing"}), "public", false).is_err());
+    // Per-block breakpoints are not part of the strict content subset yet.
+    for responses in [false, true] {
+        let mut body = request(responses);
+        if responses {
+            body["input"] = json!([{"role":"user","content":[{"type":"input_text","text":"Hello","prompt_cache_breakpoint":{"mode":"explicit"}}]}]);
+        } else {
+            body["messages"][0]["content"] = json!([{"type":"text","text":"Hello","prompt_cache_breakpoint":{"mode":"explicit"}}]);
+        }
+        assert!(
+            if responses {
+                openai::responses::decode_chat(body)
+            } else {
+                openai::decode_chat(body)
+            }
+            .is_err()
+        );
+    }
+}
+
+#[test]
+fn current_openai_cache_options_preserve_modes_ttl_and_independent_retention() {
+    for responses in [false, true] {
+        for options in [
+            json!({}),
+            json!({"mode":"implicit"}),
+            json!({"ttl":"30m"}),
+            json!({"mode":"explicit","ttl":"30m"}),
+        ] {
+            let mut body = request(responses);
+            body["prompt_cache_options"] = options.clone();
+            body["prompt_cache_retention"] = json!("24h");
+            let mut r = if responses {
+                openai::responses::decode_chat(body)
+            } else {
+                openai::decode_chat(body)
+            }
+            .unwrap();
+            for encoded in [openai::encode_chat(&r), openai::responses::encode_chat(&r)] {
+                let encoded = encoded.unwrap();
+                assert_eq!(encoded["prompt_cache_options"], options);
+                assert_eq!(encoded["prompt_cache_retention"], "24h");
+                assert!(encoded.get("prompt_cache_key").is_none());
+            }
+            r.openai.prompt_cache_retention = None;
+            assert!(anthropic::encode_chat(&r).is_err());
+            assert!(gemini::encode_chat(&r).is_err());
+        }
+    }
+}
+
+#[test]
+fn current_cache_options_reject_invalid_or_unimplemented_fields() {
+    for responses in [false, true] {
+        for options in [
+            json!("implicit"),
+            json!({"ttl":"24h"}),
+            json!({"ttl":"5m"}),
+            json!({"mode":"auto"}),
+            json!({"mode":null}),
+            json!({"ttl":null}),
+            json!({"comparison_response_id":"resp_previous"}),
+        ] {
+            let mut body = request(responses);
+            body["prompt_cache_options"] = options.clone();
+            assert!(
+                if responses {
+                    openai::responses::decode_chat(body)
+                } else {
+                    openai::decode_chat(body)
+                }
+                .is_err(),
+                "{responses}: {options}"
+            );
+        }
+        let mut body = request(responses);
+        body["prompt_cache_options"] = Value::Null;
+        let r = if responses {
+            openai::responses::decode_chat(body)
+        } else {
+            openai::decode_chat(body)
+        }
+        .unwrap();
+        assert!(
+            openai::encode_chat(&r)
+                .unwrap()
+                .get("prompt_cache_options")
+                .is_none()
+        );
+        assert!(
+            openai::responses::encode_chat(&r)
+                .unwrap()
+                .get("prompt_cache_options")
+                .is_none()
+        );
+    }
+}
+
+#[test]
+fn responses_accepts_valid_cache_option_echoes_but_rejects_unimplemented_details() {
+    let response = json!({"id":"r","object":"response","created_at":1,"model":"m","status":"completed","output":[{"type":"message","id":"msg_r","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hello"}]}]});
+    for options in [
+        Value::Null,
+        json!({}),
+        json!({"mode":"implicit","ttl":"30m"}),
+    ] {
+        let mut body = response.clone();
+        body["prompt_cache_options"] = options;
+        openai::responses::decode_chat_response(body).unwrap();
+    }
+    for options in [
+        json!({"ttl":"1h"}),
+        json!({"comparison_response_id":"prior"}),
+        json!({"mode":"unknown"}),
+    ] {
+        let mut body = response.clone();
+        body["prompt_cache_options"] = options;
+        assert!(openai::responses::decode_chat_response(body).is_err());
+    }
+}

--- a/crates/nyro-llm/tests/cache_usage_codec.rs
+++ b/crates/nyro-llm/tests/cache_usage_codec.rs
@@ -139,3 +139,59 @@ fn streamed_cache_components_cannot_regress_even_if_total_grows() {
         assert!(d.push(&event(json!({"type":"message_stop"}))).is_err());
     }
 }
+
+#[test]
+fn openai_cache_writes_round_trip_as_input_subsets_without_ttl_inference() {
+    for written in [0, 4] {
+        let chat = json!({"id":"r","object":"chat.completion","created":1,"model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"Hello"},"finish_reason":"stop"}],"usage":{"prompt_tokens":12,"completion_tokens":2,"total_tokens":14,"prompt_tokens_details":{"cached_tokens":5,"cache_write_tokens":written}}});
+        let r = openai::decode_chat_response(chat).unwrap();
+        assert_eq!(r.usage.as_ref().unwrap().total_tokens, 14);
+        for (value, details) in [
+            (
+                openai::encode_chat_response(&r).unwrap(),
+                "prompt_tokens_details",
+            ),
+            (
+                openai::responses::encode_chat_response(&r).unwrap(),
+                "input_tokens_details",
+            ),
+        ] {
+            assert_eq!(
+                value["usage"][details]["cache_write_tokens"]
+                    .as_u64()
+                    .unwrap_or(0),
+                written
+            );
+            assert_eq!(value["usage"][details]["cached_tokens"], 5);
+        }
+        let responses = openai::responses::encode_chat_response(&r).unwrap();
+        let back = openai::responses::decode_chat_response(responses).unwrap();
+        assert_eq!(back.usage.as_ref().unwrap().total_tokens, 14);
+        let anthropic = anthropic::encode_chat_response(&r).unwrap();
+        assert_eq!(anthropic["usage"]["input_tokens"], 7 - written);
+        assert_eq!(
+            anthropic["usage"]["cache_creation_input_tokens"]
+                .as_u64()
+                .unwrap_or(0),
+            written
+        );
+        assert!(anthropic["usage"].get("cache_creation").is_none());
+        assert_eq!(gemini::encode_chat_response(&r).is_ok(), written == 0);
+    }
+}
+
+#[test]
+fn invalid_openai_cache_write_subsets_are_rejected() {
+    for written in [
+        json!(-1),
+        json!(1.5),
+        Value::Null,
+        json!(8),
+        json!(u64::MAX),
+    ] {
+        let chat = json!({"id":"r","object":"chat.completion","created":1,"model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"Hello"},"finish_reason":"stop"}],"usage":{"prompt_tokens":12,"completion_tokens":2,"total_tokens":14,"prompt_tokens_details":{"cached_tokens":5,"cache_write_tokens":written}}});
+        assert!(openai::decode_chat_response(chat).is_err());
+        let responses = json!({"id":"r","object":"response","created_at":1,"model":"m","status":"completed","output":[{"type":"message","id":"msg","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hello"}]}],"usage":{"input_tokens":12,"output_tokens":2,"total_tokens":14,"input_tokens_details":{"cached_tokens":5,"cache_write_tokens":written}}});
+        assert!(openai::responses::decode_chat_response(responses).is_err());
+    }
+}

--- a/crates/nyro-llm/tests/native_anthropic_runtime.rs
+++ b/crates/nyro-llm/tests/native_anthropic_runtime.rs
@@ -851,3 +851,96 @@ async fn invalid_cache_updates_terminate_strict_and_native_streams_with_conserva
         }
     }
 }
+
+// Isolate caching from thinking/vendor extensions so rejection cannot pass for
+// an unrelated unsupported field. Each request has at most four breakpoints.
+fn cache_inputs(streaming: bool) -> Vec<Value> {
+    let mut automatic = input(false, streaming);
+    automatic["cache_control"] = json!({"type":"ephemeral","ttl":"1h"});
+    let mut placed = input(false, streaming);
+    placed["tools"] = json!([{"name":"weather","input_schema":{"type":"object"},"cache_control":{"type":"ephemeral","ttl":"1h"}}]);
+    placed["system"] = json!([
+        {"type":"text","text":"Stable instructions","cache_control":{"type":"ephemeral","ttl":"1h"}},
+        {"type":"text","text":"Uncached suffix"}
+    ]);
+    placed["messages"] = json!([
+        {"role":"user","content":[
+            {"type":"text","text":"Stable prefix"},
+            {"type":"image","source":{"type":"base64","media_type":"image/png","data":"aGVsbG8="},"cache_control":{"type":"ephemeral","ttl":"5m"}},
+            {"type":"text","text":"Uncached question"}]},
+        {"role":"assistant","content":[{"type":"tool_use","id":"call-1","name":"weather","input":{}}]},
+        {"role":"user","content":[
+            {"type":"tool_result","tool_use_id":"call-1","content":[{"type":"text","text":"Sunny"}],"cache_control":{"type":"ephemeral"}},
+            {"type":"text","text":"Continue"}]}
+    ]);
+    // A cache marker on otherwise ordinary text must independently be rejected
+    // by strict conversion, without depending on image or tool support.
+    let mut text = input(false, streaming);
+    text["messages"][0]["content"] = json!([
+        {"type":"text","text":"Stable prefix","cache_control":{"type":"ephemeral","ttl":"1h"}},
+        {"type":"text","text":"Uncached suffix"}
+    ]);
+    vec![automatic, placed, text]
+}
+
+#[tokio::test]
+async fn cache_controls_keep_ttl_and_placement_across_native_retry_only() {
+    for streaming in [false, true] {
+        let first = upstream(503, "unavailable".into(), false).await;
+        let incompatible = upstream(200, answer().to_string(), false).await;
+        let backup = upstream(
+            200,
+            if streaming {
+                sse(&frames())
+            } else {
+                answer().to_string()
+            },
+            streaming,
+        )
+        .await;
+        let limit = ConcurrencyLimit::new(1).unwrap();
+        for body in cache_inputs(streaming) {
+            let gateway = runtime(
+                config(&[
+                    (&first, "anthropic", true),
+                    (&incompatible, "anthropic", false),
+                    (&incompatible, "openai", true),
+                    (&backup, "anthropic", true),
+                ]),
+                &limit,
+                Options::default(),
+            );
+            let before = backup.calls.lock().unwrap().len();
+            let response = invoke(&gateway, body.clone()).await;
+            assert_eq!(response.status(), StatusCode::OK);
+            let output = consume(response).await;
+            assert!(output.contains(if streaming { "message_stop" } else { "晴天" }));
+            assert_eq!(limit.available(), 1);
+            assert!(incompatible.calls.lock().unwrap().is_empty());
+            let mut expected = body.clone();
+            expected["model"] = json!("private-model");
+            assert_eq!(
+                first.calls.lock().unwrap().last().unwrap()["body"],
+                expected
+            );
+            assert_eq!(backup.calls.lock().unwrap().len(), before + 1);
+            assert_eq!(
+                backup.calls.lock().unwrap().last().unwrap()["body"],
+                expected
+            );
+            for kind in ["anthropic", "openai", "gemini"] {
+                let strict = runtime(
+                    config(&[(&incompatible, kind, kind != "anthropic")]),
+                    &limit,
+                    Options::default(),
+                );
+                assert_eq!(
+                    invoke(&strict, body.clone()).await.status(),
+                    StatusCode::BAD_REQUEST
+                );
+                assert!(incompatible.calls.lock().unwrap().is_empty());
+                assert_eq!(limit.available(), 1);
+            }
+        }
+    }
+}

--- a/crates/nyro-llm/tests/native_gemini_runtime.rs
+++ b/crates/nyro-llm/tests/native_gemini_runtime.rs
@@ -688,3 +688,57 @@ async fn optional_null_response_fields_remain_compatible_with_strict_codec() {
         payload
     );
 }
+
+#[tokio::test]
+async fn cached_resource_reference_survives_native_retry_without_cross_protocol_fallback() {
+    for streaming in [false, true] {
+        let first = upstream(503, "unavailable".into(), false).await;
+        let incompatible = upstream(200, answer().to_string(), false).await;
+        let backup = upstream(
+            200,
+            if streaming {
+                sse(&frames())
+            } else {
+                answer().to_string()
+            },
+            streaming,
+        )
+        .await;
+        let limit = ConcurrencyLimit::new(1).unwrap();
+        let mut body = input(false);
+        body["cachedContent"] = json!("cachedContents/existing-cache");
+        let gateway = runtime(
+            config(&[
+                (&first, "gemini", true),
+                (&incompatible, "gemini", false),
+                (&incompatible, "openai", true),
+                (&backup, "gemini", true),
+            ]),
+            &limit,
+            Options::default(),
+        );
+        let response = invoke(&gateway, body.clone(), streaming).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        consume(response).await;
+        assert_eq!(limit.available(), 1);
+        assert!(incompatible.calls.lock().unwrap().is_empty());
+        for up in [&first, &backup] {
+            let calls = up.calls.lock().unwrap();
+            assert_eq!(calls.len(), 1);
+            assert_eq!(calls[0]["body"], body);
+        }
+        for kind in ["gemini", "openai", "anthropic"] {
+            let strict = runtime(
+                config(&[(&incompatible, kind, kind != "gemini")]),
+                &limit,
+                Options::default(),
+            );
+            assert_eq!(
+                invoke(&strict, body.clone(), streaming).await.status(),
+                StatusCode::BAD_REQUEST
+            );
+            assert!(incompatible.calls.lock().unwrap().is_empty());
+            assert_eq!(limit.available(), 1);
+        }
+    }
+}

--- a/crates/nyro-llm/tests/native_responses_runtime.rs
+++ b/crates/nyro-llm/tests/native_responses_runtime.rs
@@ -130,8 +130,9 @@ fn request(body: Value) -> Request<Body> {
 fn input(extended: bool, stream: bool) -> Value {
     let mut body = json!({"model":"public","input":"Hello","stream":stream});
     if extended {
+        body["prompt_cache_options"] = json!({"mode":"explicit","ttl":"30m"});
         body["input"] = json!([
-            {"role":"user","content":[{"type":"input_text","text":"Describe"},{"type":"input_image","image_url":"https://example.com/image.png"}]},
+            {"role":"user","content":[{"type":"input_text","text":"Describe","prompt_cache_breakpoint":{"mode":"explicit"}},{"type":"input_image","image_url":"https://example.com/image.png"}]},
             {"type":"reasoning","id":"rs_history","summary":[],"encrypted_content":"opaque-history"},
             {"type":"message","id":"msg_history","role":"assistant","phase":"commentary","content":[{"type":"output_text","text":"Checking","annotations":[]}]},
             {"type":"function_call","call_id":"call_1","name":"weather","arguments":"{}"},
@@ -147,7 +148,7 @@ fn answer() -> Value {
     json!({"id":"resp_answer","object":"response","model":"private-model","created_at":100,"status":"completed","error":null,"incomplete_details":null,
         "output":[{"type":"reasoning","id":"rs_1","summary":[{"type":"summary_text","text":"想一想"}],"encrypted_content":"opaque-answer"},
             {"type":"message","id":"msg_1","role":"assistant","status":"completed","phase":"final_answer","content":[{"type":"output_text","text":"晴天","annotations":[{"type":"url_citation","url":"https://example.com"}],"logprobs":[]}]}],
-        "usage":{"input_tokens":10,"output_tokens":5,"total_tokens":15,"input_tokens_details":{"cached_tokens":6},"output_tokens_details":{"reasoning_tokens":3},"vendor_tokens":99},"vendor_field":{"preserve":true}})
+        "usage":{"input_tokens":10,"output_tokens":5,"total_tokens":15,"input_tokens_details":{"cached_tokens":6,"cache_write_tokens":4},"output_tokens_details":{"reasoning_tokens":3},"vendor_tokens":99},"vendor_field":{"preserve":true}})
 }
 fn frames() -> Vec<Value> {
     let mut start = answer();
@@ -424,6 +425,22 @@ async fn invalid_json_envelopes_and_usage_fail_without_retry_or_secret_leaks() {
         ("input_tokens_details", json!({"cached_tokens":11})),
         ("output_tokens_details", json!({"reasoning_tokens":6})),
         ("input_tokens_details", json!({"cached_tokens":-1})),
+        (
+            "input_tokens_details",
+            json!({"cached_tokens":6,"cache_write_tokens":5}),
+        ),
+        (
+            "input_tokens_details",
+            json!({"cached_tokens":6,"cache_write_tokens":-1}),
+        ),
+        (
+            "input_tokens_details",
+            json!({"cached_tokens":6,"cache_write_tokens":null}),
+        ),
+        (
+            "input_tokens_details",
+            json!({"cached_tokens":6,"cache_write_tokens":18446744073709551615u64}),
+        ),
     ] {
         let mut bad = answer();
         bad["usage"][field] = value;
@@ -476,6 +493,11 @@ async fn invalid_sse_identity_sequence_terminal_and_truncation_fail_and_release(
     ] {
         let mut events = valid.clone();
         events[5]["response"][field] = value;
+        cases.push(sse(&events));
+    }
+    for written in [json!(-1), Value::Null, json!(5), json!(u64::MAX)] {
+        let mut events = valid.clone();
+        events[5]["response"]["usage"]["input_tokens_details"]["cache_write_tokens"] = written;
         cases.push(sse(&events));
     }
     let mut duplicate = valid.clone();

--- a/crates/nyro-llm/tests/native_runtime.rs
+++ b/crates/nyro-llm/tests/native_runtime.rs
@@ -127,17 +127,17 @@ fn input() -> Value {
 }
 fn extended_input() -> Value {
     json!({"model":"public","messages":[
-        {"role":"user","content":"Weather?"},
+        {"role":"user","content":[{"type":"text","text":"Weather?","prompt_cache_breakpoint":{"mode":"explicit"}}]},
         {"role":"assistant","content":null,"reasoning_content":"Check weather",
          "tool_calls":[{"id":"call-1","type":"function","function":{"name":"weather","arguments":"{}"}}]},
         {"role":"tool","tool_call_id":"call-1","content":"Sunny"}
-    ],"max_tokens":16,"thinking":{"type":"enabled"},"vendor_option":{"nested":[true,7,null]}})
+    ],"max_tokens":16,"prompt_cache_options":{"mode":"explicit","ttl":"30m"},"thinking":{"type":"enabled"},"vendor_option":{"nested":[true,7,null]}})
 }
 fn answer() -> Value {
     json!({"id":"answer","object":"chat.completion","created":1,"model":"private-model",
         "request_id":"vendor-request","vendor_field":{"ok":true},
         "choices":[{"index":0,"message":{"role":"assistant","content":"晴天","reasoning_content":"Consider weather"},"finish_reason":"stop"}],
-        "usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5,"vendor_billable_tokens":9}})
+        "usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5,"prompt_tokens_details":{"cached_tokens":1,"cache_write_tokens":2},"vendor_billable_tokens":9}})
 }
 fn frames() -> Vec<Value> {
     vec![
@@ -145,7 +145,7 @@ fn frames() -> Vec<Value> {
             "choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"想一想","content":"晴天"},"finish_reason":null}]}),
         json!({"id":"answer","object":"chat.completion.chunk","created":1,"model":"private-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}),
         json!({"id":"answer","object":"chat.completion.chunk","created":1,"model":"private-model","choices":[],"request_id":"usage-request",
-            "usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5,"vendor_billable_tokens":9}}),
+            "usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5,"prompt_tokens_details":{"cached_tokens":1,"cache_write_tokens":2},"vendor_billable_tokens":9}}),
     ]
 }
 fn sse(done: bool) -> String {
@@ -521,5 +521,45 @@ async fn native_stream_accepts_whitespace_around_done_but_rejects_invalid_delta_
             assert!(output.ends_with("data: [DONE]\n\n"));
         }
         assert_eq!(limit.available(), 1);
+    }
+}
+
+#[tokio::test]
+async fn native_cache_write_counts_reject_invalid_subsets_even_when_stream_usage_is_hidden() {
+    for written in [json!(-1), Value::Null, json!(3), json!(u64::MAX)] {
+        for streaming in [false, true] {
+            let mut response = answer();
+            response["usage"]["prompt_tokens_details"]["cache_write_tokens"] = written.clone();
+            let text = if streaming {
+                let mut frames = frames();
+                frames[2]["usage"] = response["usage"].clone();
+                let mut s: String = frames.iter().map(|v| format!("data: {v}\n\n")).collect();
+                s.push_str("data: [DONE]\n\n");
+                s
+            } else {
+                response.to_string()
+            };
+            let up = upstream(200, text, streaming).await;
+            let backup = upstream(200, answer().to_string(), false).await;
+            let limit = ConcurrencyLimit::new(1).unwrap();
+            let gateway = runtime(
+                config(&[(&up, "openai", true), (&backup, "openai", true)]),
+                &limit,
+                Options::default(),
+            );
+            let mut body = input();
+            body["stream"] = json!(streaming);
+            let result = invoke(&gateway, body).await;
+            if streaming {
+                assert_eq!(result.status(), StatusCode::OK);
+                assert!(to_bytes(result.into_body(), 65536).await.is_err());
+            } else {
+                assert_eq!(result.status(), StatusCode::BAD_GATEWAY);
+                consume(result).await;
+            }
+            assert_eq!(up.calls.lock().unwrap().len(), 1);
+            assert!(backup.calls.lock().unwrap().is_empty());
+            assert_eq!(limit.available(), 1);
+        }
     }
 }

--- a/crates/nyro-llm/tests/responses_runtime.rs
+++ b/crates/nyro-llm/tests/responses_runtime.rs
@@ -177,6 +177,23 @@ impl Drop for Fixture {
         self.task.abort();
     }
 }
+fn echo_cache_options(response: &mut Value, request: &Value, format: &str) {
+    if request.get("prompt_cache_options").is_none() {
+        return;
+    }
+    if format == "responses" {
+        response["prompt_cache_options"] = request["prompt_cache_options"].clone();
+    }
+    if !response["usage"].is_null() {
+        let details = if format == "responses" {
+            "input_tokens_details"
+        } else {
+            "prompt_tokens_details"
+        };
+        response["usage"][details] = json!({"cached_tokens":1,"cache_write_tokens":2});
+    }
+}
+
 async fn upstream(format: &'static str, mode: &'static str) -> Fixture {
     let calls = Arc::new(Mutex::new(Vec::new()));
     let observed = calls.clone();
@@ -216,6 +233,31 @@ async fn upstream(format: &'static str, mode: &'static str) -> Fixture {
                 } else {
                     frames(format, mode != "normal")
                 };
+                // Responses echoes request cache options on response envelopes.
+                let text = if matches!(format, "responses" | "openai")
+                    && body.get("prompt_cache_options").is_some()
+                {
+                    text.split_inclusive('\n')
+                        .map(|line| {
+                            if let Some(data) = line
+                                .strip_prefix("data: ")
+                                .filter(|data| data.trim() != "[DONE]")
+                            {
+                                let mut event: Value = serde_json::from_str(data).unwrap();
+                                if format == "openai" {
+                                    echo_cache_options(&mut event, &body, format);
+                                } else if let Some(response) = event.get_mut("response") {
+                                    echo_cache_options(response, &body, format);
+                                }
+                                format!("data: {event}\n")
+                            } else {
+                                line.to_owned()
+                            }
+                        })
+                        .collect()
+                } else {
+                    text
+                };
                 // Split across arbitrary SSE and UTF-8 boundaries, as real transports do.
                 let chunks: Vec<_> = text
                     .into_bytes()
@@ -247,7 +289,13 @@ async fn upstream(format: &'static str, mode: &'static str) -> Fixture {
                             value["choices"][0]["finish_reason"] = json!("length");
                             value
                         } else {
-                            response(format)
+                            let mut response = response(format);
+                            if matches!(format, "responses" | "openai")
+                                && body.get("prompt_cache_options").is_some()
+                            {
+                                echo_cache_options(&mut response, &body, format);
+                            }
+                            response
                         }
                         .to_string(),
                     ))
@@ -1705,6 +1753,167 @@ async fn image_detail_is_preserved_or_rejected_before_dispatch() {
                     );
                 }
             }
+        }
+    }
+}
+
+#[tokio::test]
+async fn cache_controls_survive_openai_api_conversion_and_filter_other_targets() {
+    for target in FORMATS {
+        let fixture = upstream(target, "normal").await;
+        let limit = ConcurrencyLimit::new(1).unwrap();
+        let gateway = runtime(&fixture, target, limit.clone(), Options::default());
+        for source in ["openai", "responses"] {
+            for streaming in [false, true] {
+                for (field, control, valid) in [
+                    ("prompt_cache_retention", json!("in_memory"), true),
+                    ("prompt_cache_retention", json!("24h"), true),
+                    ("prompt_cache_retention", Value::Null, true),
+                    ("prompt_cache_retention", json!("1h"), false),
+                    ("prompt_cache_retention", json!(24), false),
+                    (
+                        "prompt_cache_options",
+                        json!({"mode":"implicit","ttl":"30m"}),
+                        true,
+                    ),
+                    (
+                        "prompt_cache_options",
+                        json!({"mode":"explicit","ttl":"30m"}),
+                        true,
+                    ),
+                    ("prompt_cache_options", json!({}), true),
+                    ("prompt_cache_options", Value::Null, true),
+                    ("prompt_cache_options", json!({"ttl":"24h"}), false),
+                    ("prompt_cache_options", json!({"mode":"auto"}), false),
+                ] {
+                    let (parts, body) = request(source, streaming).into_parts();
+                    let mut value: Value =
+                        serde_json::from_slice(&to_bytes(body, 65536).await.unwrap()).unwrap();
+                    value[field] = control.clone();
+                    if streaming && source == "openai" {
+                        value["stream_options"] = json!({"include_usage":true});
+                    }
+                    let before = fixture.calls.lock().unwrap().len();
+                    let response = gateway
+                        .handle(
+                            Request::from_parts(parts, Body::from(value.to_string())),
+                            CancellationToken::new(),
+                        )
+                        .await;
+                    let allowed =
+                        control.is_null() || (valid && matches!(target, "openai" | "responses"));
+                    assert_eq!(
+                        response.status(),
+                        if allowed {
+                            StatusCode::OK
+                        } else {
+                            StatusCode::BAD_REQUEST
+                        },
+                        "{source} -> {target}, stream={streaming}, {field}={control}"
+                    );
+                    let bytes = to_bytes(response.into_body(), 65536).await.unwrap();
+                    assert_eq!(limit.available(), 1);
+                    let calls = fixture.calls.lock().unwrap();
+                    assert_eq!(calls.len(), before + usize::from(allowed));
+                    if allowed {
+                        let result = if streaming {
+                            stream_snapshot(source, &bytes)
+                        } else {
+                            snapshot(source, &serde_json::from_slice(&bytes).unwrap())
+                        };
+                        assert_eq!(result["text"], "Hello");
+                        let call = calls.last().unwrap();
+                        assert_eq!(call["body"][field], control);
+                        if field == "prompt_cache_options" && !control.is_null() {
+                            assert_eq!(result["usage"], json!([3, 2, 5]));
+                            let values = if streaming {
+                                sse_values(&bytes)
+                            } else {
+                                vec![serde_json::from_slice(&bytes).unwrap()]
+                            };
+                            let usage = values
+                                .iter()
+                                .rev()
+                                .find_map(|v| {
+                                    let u = if streaming && source == "responses" {
+                                        &v["response"]["usage"]
+                                    } else {
+                                        &v["usage"]
+                                    };
+                                    u.is_object().then_some(u)
+                                })
+                                .unwrap();
+                            let details = if source == "responses" {
+                                "input_tokens_details"
+                            } else {
+                                "prompt_tokens_details"
+                            };
+                            assert_eq!(usage[details]["cached_tokens"], 1);
+                            assert_eq!(usage[details]["cache_write_tokens"], 2);
+                        }
+                        assert!(!call["headers"].to_string().contains("client-secret"));
+                        if control.is_null() {
+                            assert!(call["body"].get(field).is_none());
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn cache_write_usage_settles_once_even_when_chat_stream_usage_is_hidden() {
+    for target in ["openai", "responses"] {
+        let fixture = upstream(target, "normal").await;
+        for streaming in [false, true] {
+            let mut provider = json!({"kind":"openai","base_url":format!("{}/v1",fixture.base)});
+            if target == "responses" {
+                provider["api"] = json!("responses");
+            }
+            let config = serde_json::from_value(json!({"providers":{"p":provider},"models":{"public":{"provider":"p","upstream_model":"internal","workloads":["chat"],"subjects":["alice"],"quota":{"total_tokens":10,"reserve_tokens":1}}}})).unwrap();
+            let limit = ConcurrencyLimit::new(1).unwrap();
+            let gateway = Runtime::new(
+                config,
+                Arc::new(
+                    ApiKeys::new(vec![ApiKey {
+                        id: "alice".into(),
+                        secret: "client-secret".into(),
+                    }])
+                    .unwrap(),
+                ),
+                limit.clone(),
+                Options::default(),
+            )
+            .unwrap();
+            let before = fixture.calls.lock().unwrap().len();
+            for i in 0..3 {
+                let (parts, body) = request("openai", streaming).into_parts();
+                let mut body: Value =
+                    serde_json::from_slice(&to_bytes(body, 65536).await.unwrap()).unwrap();
+                body["prompt_cache_options"] = json!({"mode":"implicit","ttl":"30m"});
+                let response = gateway
+                    .handle(
+                        Request::from_parts(parts, Body::from(body.to_string())),
+                        CancellationToken::new(),
+                    )
+                    .await;
+                assert_eq!(
+                    response.status(),
+                    if i < 2 {
+                        StatusCode::OK
+                    } else {
+                        StatusCode::TOO_MANY_REQUESTS
+                    }
+                );
+                let bytes = to_bytes(response.into_body(), 65536).await.unwrap();
+                if i < 2 && streaming {
+                    assert!(String::from_utf8_lossy(&bytes).contains("[DONE]"));
+                    assert!(sse_values(&bytes).iter().all(|v| v.get("usage").is_none()));
+                }
+                assert_eq!(limit.available(), 1);
+            }
+            assert_eq!(fixture.calls.lock().unwrap().len(), before + 2);
         }
     }
 }

--- a/crates/nyro-protocol/src/openai/chat.rs
+++ b/crates/nyro-protocol/src/openai/chat.rs
@@ -214,6 +214,10 @@ pub struct Request {
     pub safety_identifier: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prompt_cache_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_cache_retention: Option<super::PromptCacheRetention>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_cache_options: Option<super::PromptCacheOptions>,
 }
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -231,6 +235,12 @@ pub struct Usage {
 pub struct PromptTokensDetails {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cached_tokens: Option<u64>,
+    #[serde(
+        default,
+        deserialize_with = "super::present",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub cache_write_tokens: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub audio_tokens: Option<u64>,
 }

--- a/crates/nyro-protocol/src/openai/mod.rs
+++ b/crates/nyro-protocol/src/openai/mod.rs
@@ -1,5 +1,52 @@
-//! OpenAI Chat Completions and Embeddings wire types.
+//! OpenAI wire types and cache controls shared by Chat and Responses.
 pub mod chat;
 pub mod embedding;
 pub mod responses;
 pub mod stream;
+
+/// Retention policy shared by Chat Completions and Responses.
+/// Model support is checked by the upstream; absence selects its default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum PromptCacheRetention {
+    #[serde(rename = "in_memory")]
+    InMemory,
+    #[serde(rename = "24h")]
+    Extended24h,
+}
+
+/// Optional fields stay absent so model-specific defaults remain upstream-owned.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PromptCacheOptions {
+    #[serde(
+        default,
+        deserialize_with = "present",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub mode: Option<PromptCacheMode>,
+    #[serde(
+        default,
+        deserialize_with = "present",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub ttl: Option<PromptCacheTtl>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptCacheMode {
+    Implicit,
+    Explicit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum PromptCacheTtl {
+    #[serde(rename = "30m")]
+    ThirtyMinutes,
+}
+
+fn present<'de, D: serde::Deserializer<'de>, T: serde::Deserialize<'de>>(
+    deserializer: D,
+) -> Result<Option<T>, D::Error> {
+    T::deserialize(deserializer).map(Some)
+}

--- a/crates/nyro-protocol/src/openai/responses.rs
+++ b/crates/nyro-protocol/src/openai/responses.rs
@@ -27,6 +27,8 @@ pub struct Request {
     pub user: Option<String>,
     pub safety_identifier: Option<String>,
     pub prompt_cache_key: Option<String>,
+    pub prompt_cache_retention: Option<super::PromptCacheRetention>,
+    pub prompt_cache_options: Option<super::PromptCacheOptions>,
 }
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
@@ -229,6 +231,12 @@ pub struct Usage {
 #[serde(deny_unknown_fields)]
 pub struct InputTokensDetails {
     pub cached_tokens: u64,
+    #[serde(
+        default,
+        deserialize_with = "super::present",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub cache_write_tokens: Option<u64>,
 }
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -517,7 +517,9 @@ Chat 流使用自己的事件类型，不要求所有交互实现流接口。当
 
 当前 quota 实现为 `nyro-limit` 中按通用单位原子预留与结算的进程内账本，`nyro-llm` 将其映射到公开模型的累计输入加输出 token。模型可选配置 `quota.total_tokens` 与 `quota.reserve_tokens`，每次实际上游尝试前独立预留；完整 JSON／SSE 协议终止后按有效用量结算，连接建立失败全额释放，其他失败、取消、断流和用量缺失按预留与有效已知用量的较大值扣减。上游实际消耗可以超过预留，超额如实记账并阻止后续准入；配置预留不是可信的消耗上界，当前不承诺真实上游 token 硬上限，也不提供金额、持久化或多副本协调。
 
-缓存计量属于 LLM 协议语义：`Usage.prompt_tokens` 包含普通输入、缓存读取和缓存写入，读取细分复用 `prompt_tokens_details.cached_tokens`，写入细分由可选的类型化 `Usage.cache_creation` 表达，TTL 明细是写入子集，不重复计数。可选写入明细使用 `Box<CacheCreationUsage>`，避免增大普通响应；直接构造 `Usage` 的消费者需提供该字段，无写入时设为 `None`。转换和校验由 `nyro-llm` codec 负责，wire 字段归 `nyro-protocol`；不引入通用 JSON 扩展袋、新 crate 或内核职责。非零写入明细当前只能在 Anthropic 严格输出中保留，其他目标明确拒绝；原生路径保留原始 JSON，观测和 quota 使用经过校验的总量。请求缓存策略及金额计费仍是独立待办。
+协议字段、默认行为和约束以当前官方文档为准；旧代码用于核对部署行为和迁移差异，不作为语义正确性的标准。缓存控制按协议表达：OpenAI `prompt_cache_options` 的 mode／TTL 和兼容 retention 定义于 `nyro-protocol::openai`，由既有 `OpenAiOptions` 携带，Chat／Responses codec 分别编码；不把它们抽象成可与 Anthropic 缓存断点、Gemini 资源引用互换的通用 TTL。缺省字段由上游决定，Nyro 不注入默认值或断点。当前内容块断点／Anthropic cache_control／Gemini cachedContent 保留在匹配的原生路径，严格或不兼容的转换明确拒绝。控制字段与用量支持范围分别验收；当前同时支持 OpenAI `cache_write_tokens`，复用 `Usage.cache_creation` 且不推测 TTL。读取与写入之和不得超过包含缓存的输入总量；原生路径保留原文并校验已知子集。新官方字段未实现时应作为明确的支持边界记录，不能据旧类型断言协议本身无法表达。
+
+缓存计量属于 LLM 协议语义：`Usage.prompt_tokens` 包含普通输入、缓存读取和缓存写入，读取细分复用 `prompt_tokens_details.cached_tokens`，写入细分由可选的类型化 `Usage.cache_creation` 表达，TTL 明细是写入子集，不重复计数。可选写入明细使用 `Box<CacheCreationUsage>`，避免增大普通响应；直接构造 `Usage` 的消费者需提供该字段，无写入时设为 `None`。转换和校验由 `nyro-llm` codec 负责，wire 字段归 `nyro-protocol`；不引入通用 JSON 扩展袋、新 crate 或内核职责。无 TTL 明细的写入计数可在 OpenAI Chat／Responses／Anthropic 间映射，TTL 明细仅由 Anthropic 严格输出保留，Gemini 拒绝非零写入；原生路径保留原始 JSON，观测和 quota 使用经过校验的总量。请求缓存控制的当前子集见上文，跨协议策略映射及金额计费仍是独立待办。
 
 根程序通过 `nyro_llm::runtime::SharedResources` 显式共享健康、rate 和 quota 注册表。quota 已消耗及在途账本在模型移除／加回后继续保留；有活跃绑定或已消费余额时修改规则会拒绝候选构建，避免配置变更清零。进程重启会重置进程内状态。quota 超限返回原生协议 `429`，不带 `Retry-After` 并立即释放并发许可；其之前的 rate 准入不退款。计量、协议映射和资源组合均未进入 `nyro-kernel`。
 
@@ -560,7 +562,7 @@ schema 的所有权不因共用数据库而合并。修改实际迁移源时仍�
 | 阶段 | 当前进度 | 差异跟踪 |
 |---|---|---|
 | 内核、代际、文件配置 | 基础机制已落地；SIGHUP 重载已有回归 | 后续能力必须保持生命周期与清理约束 |
-| LLM 数据面 | 主要执行链已落地；模型发现 G01 已补齐，G02 已支持显式开启 OpenAI Chat／无状态 Responses／Anthropic Messages／单候选 Gemini 原生 JSON/SSE 保真；G04 已补充 Anthropic／Gemini 完整工具结果批次、显式错误状态边界、文本结果块与 Gemini ID／顺序校验；函数 Schema 已补充 JSON 约束保留、Gemini 方言转换与 strict 目标边界；G03 已补充用户图片输入及目标限制、缓存读取转换与 Anthropic 缓存写入／TTL 计量边界；整体兼容对齐未完成 | G02–G09 |
+| LLM 数据面 | 主要执行链已落地；模型发现 G01 已补齐，G02 已支持显式开启 OpenAI Chat／无状态 Responses／Anthropic Messages／单候选 Gemini 原生 JSON/SSE 保真；G04 已补充 Anthropic／Gemini 完整工具结果批次、显式错误状态边界、文本结果块与 Gemini ID／顺序校验；函数 Schema 已补充 JSON 约束保留、Gemini 方言转换与 strict 目标边界；G03 已补充用户图片输入及目标限制、缓存读取转换与 Anthropic 缓存写入／TTL 计量边界、OpenAI 当前缓存选项／兼容 retention 及原生缓存放置回归；整体兼容对齐未完成 | G02–G09 |
 | 控制面、存储、管理与持久化观测 | 尚未接入新架构 | G10–G12 |
 | 工具、部署和旧入口切换 | 尚未完成切换验收 | G11、G13 |
 

--- a/docs/design/rust-migration-gaps.md
+++ b/docs/design/rust-migration-gaps.md
@@ -1,6 +1,6 @@
 # Rust 迁移差异审计
 
-审计基线：`d943c174`（2026-09-09，含 PR #323）。后续关闭状态：G01 已由 PR #324 补齐；G02 的 OpenAI Chat／Anthropic Messages／Gemini／无状态 Responses 原生增量已由 PR #325–#328 合并，G04 的工具历史／结果与 Schema 增量已由 PR #329–#331 合并，G03 用户图片输入已由 PR #332 合并，本轮在 `2dc478e4` 上推进缓存用量计量，其余差异继续跟踪。本文核对仓库实现和测试，不代表真实厂商或 SDK 兼容认证。[架构文档](architecture.md)仍是目标设计，[实验性代理指南](../standalone/rust-proxy_CN.md)说明当前支持范围。
+审计基线：`d943c174`（2026-09-09，含 PR #323）。后续关闭状态：G01 已由 PR #324 补齐；G02 的 OpenAI Chat／Anthropic Messages／Gemini／无状态 Responses 原生增量已由 PR #325–#328 合并，G04 的工具历史／结果与 Schema 增量已由 PR #329–#331 合并，G03 用户图片输入与缓存用量已由 PR #332–#333 合并，本轮在 `c41d1d29` 上推进官方缓存控制字段与保留边界，其余差异继续跟踪。本文核对仓库实现和测试，不代表真实厂商或 SDK 兼容认证。[架构文档](architecture.md)仍是目标设计，[实验性代理指南](../standalone/rust-proxy_CN.md)说明当前支持范围。
 
 **新文件配置 LLM 数据面已具备主要执行和生命周期机制，尚不能替换已发布 Server。** 同名能力不等于契约已迁移：模型 token bucket 不等于 API Key 请求窗口；存在 Responses 端点也不等于兼容 Codex 账号通道。
 
@@ -28,7 +28,7 @@
 |---|---|---|---|
 | G01 模型发现 | 已落地 | [旧模型列表](../../crates/nyro-core/src/proxy/handler.rs)的发现能力已由[新运行时](../../crates/nyro-llm/src/runtime.rs)承接；[模型列表测试](../../crates/nyro-llm/tests/models_runtime.rs)与[重载进程测试](../../tests/proxy_reload_smoke.py)覆盖过滤及代际变化。 | 按授权返回稳定排序的公开别名；匿名／绑定／无效／歧义凭证、空列表、成功／失败重载、密钥轮换和预算隔离已覆盖。无效密钥明确拒绝，不沿用旧公开列表回退；密钥到期仍由 G06 跟踪。 |
 | G02 同协议保真 | 部分 | [旧调度器](../../crates/nyro-core/src/proxy/dispatcher/mod.rs)按条件选择 Native 模式；[请求构建](../../crates/nyro-core/src/provider/common/pipeline.rs)和[非流式响应](../../crates/nyro-core/src/proxy/dispatcher/non_stream.rs)可跳过 IR 往返。[新运行时](../../crates/nyro-llm/src/runtime/native.rs)通过 Provider `native_chat: true` 保留匹配的 OpenAI Chat／无状态 Responses／Anthropic Messages／单候选 Gemini 请求、JSON 响应及 SSE 扩展；默认仍严格转换。 | OpenAI Chat／无状态 Responses／Anthropic Messages 和单候选 Gemini 的别名路由、usage、凭证隔离、重试兼容筛选、有界解析及流终态已覆盖；多候选／独立工具提示词计量和完整客户端仍待验收；Responses 已补无状态原生 mock 验证。Gemini 原生保留上游 modelVersion。只保留 JSON 字段，不承诺字节或任意 Header 透传；跨协议原始请求仍须通过来源严格 codec。 |
-| G03 推理、缓存与媒体语义 | 部分 | [旧转换测试](../../crates/nyro-core/tests/protocol_conversion.rs)覆盖 thinking／签名回放、`reasoning_content`、think-tag 归一化和 Gemini `fileData`。[新版限制](../standalone/rust-proxy_CN.md)的严格转换路径仍拒绝未支持的 Chat 内容块、缓存控制扩展和 Responses reasoning items；OpenAI Chat／Responses／Anthropic Messages／Gemini 原生模式保留这些 JSON 字段；新[用户图片回归](../../crates/nyro-llm/tests/image_codec.rs)补充四格式内嵌 PNG／JPEG／WebP 及三格式 URL 引用转换，保持 detail／格式／角色边界。新增[缓存用量回归](../../crates/nyro-llm/tests/cache_usage_codec.rs)覆盖缓存读取转换、Anthropic 写入／TTL 保留与拒绝边界、总量及流式累计校验。推理、缓存控制及其余媒体仍待处理。 | 为保留客户端建立字段／场景矩阵，保留可表达语义，明确拒绝不可表达的跨协议转换。OpenAI Chat 已有图片／音频类型字段，不能笼统说所有多模态都缺失；新增独立 Image/Audio/Video 操作另算范围。 |
+| G03 推理、缓存与媒体语义 | 部分 | [旧转换测试](../../crates/nyro-core/tests/protocol_conversion.rs)覆盖 thinking／签名回放、`reasoning_content`、think-tag 归一化和 Gemini `fileData`。[新版限制](../standalone/rust-proxy_CN.md)的严格转换路径仍拒绝未支持的 Chat 内容块、缓存控制扩展和 Responses reasoning items；OpenAI Chat／Responses／Anthropic Messages／Gemini 原生模式保留这些 JSON 字段；新[用户图片回归](../../crates/nyro-llm/tests/image_codec.rs)补充四格式内嵌 PNG／JPEG／WebP 及三格式 URL 引用转换，保持 detail／格式／角色边界。新增[缓存用量回归](../../crates/nyro-llm/tests/cache_usage_codec.rs)覆盖缓存读取转换、Anthropic 写入／TTL 保留与拒绝边界、总量及流式累计校验。新增[请求缓存控制回归](../../crates/nyro-llm/tests/cache_control_codec.rs)覆盖 OpenAI 当前 options／兼容 retention 及不兼容目标边界，原生路径补充缓存放置、TTL 和资源引用重试证据。推理、严格断点转换、其他未实现用量扩展及其余媒体仍待处理。 | 为保留客户端建立字段／场景矩阵，保留可表达语义，明确拒绝不可表达的跨协议转换。OpenAI Chat 已有图片／音频类型字段，不能笼统说所有多模态都缺失；新增独立 Image/Audio/Video 操作另算范围。 |
 | G04 工具历史与 Schema 处理 | 部分／待取舍 | 旧转换测试包含合成调用、重复 ID 修复、丢弃中间文本／孤立调用、Gemini Schema 裁剪。新 [Anthropic](../../crates/nyro-llm/tests/anthropic_codec.rs)／[Gemini](../../crates/nyro-llm/tests/gemini_codec.rs) encoder 保留完整结果批次及后续文本，拒绝缺失／重复／交错批次；Anthropic 显式错误、空结果、[Responses](../../crates/nyro-llm/tests/responses_codec.rs) 文本块数组及 Gemini ID／顺序已补充。多块结果到 Gemini、跨协议错误标志映射和媒体结果明确拒绝。[Schema 回归](../../crates/nyro-llm/tests/tool_schema_codec.rs)已覆盖 JSON Schema 对象保留、Gemini 计数／类型／嵌套方言转换及 strict 目标筛选；不裁剪引用或约束。完整客户端／厂商验收仍待后续。 | 回放并行调用、交错文本、工具结果和 Schema，保留合法客户端历史；不自动迁移虚构调用或丢内容的处理。区分有意拒绝和兼容回退。 |
 | G05 Provider 通道与凭证 | 部分 | 旧版有[厂商适配](../../crates/nyro-core/src/provider/mod.rs)、[账号认证 driver](../../crates/nyro-core/src/auth/drivers/mod.rs)和 Vertex 服务账号支持。新 Provider 配置只有协议 kind、可选 OpenAI API、URL 和可选静态 API Key。 | 迁移必要端点、Header 和凭证行为，不向 driver 传递 Gateway 或数据库实体。账号授权、刷新、持久化归控制面；driver 消费已解析凭证。详见下方清单。 |
 | G06 API Key 生命周期 | 部分 | [旧授权](../../crates/nyro-core/src/proxy/dispatcher/auth.rs)检查启用状态、过期时间和模型绑定。新 `ApiKey` 只有 `id`、`secret`；可以重载移除密钥，但没有到期自动失效。 | 对新准入执行到期检查；发布配置保留绑定及禁用语义，验证时间边界和重载；明确已准入请求保持原代际。模型发现与调用授权保持一致。 |
@@ -76,7 +76,7 @@
 | 4 | G10–G12：最小 `nyro serve`，先 SQLite 和一条管理到发布路径，再补 Postgres 等价与其余管理能力。 | 持久化 → 校验 → 发布 → 新请求使用快照；失败保留活动代际；重启／数据兼容；WebUI/API 与观测一致。可与兼容工作并行推进，单独完成不代表可发布替换。 |
 | 5 | G11/G13：部署、工具、发布切换。 | 文件／控制面等价，保留 CLI、录制客户端矩阵、支持平台构建、迁移／恢复说明全部过关后移除旧入口。 |
 
-步骤 1 已完成；步骤 2 已完成 16 份录制样本分类、OpenAI Chat／Anthropic Messages 原生增量及单候选 Gemini mock 验证，无状态 Responses 原生 mock 验证也已完成；PR #329 补充四种入口到 Anthropic 的完整并行工具结果历史转换，PR #330 补充工具错误、空／分块文本结果及 Gemini ID／批次语义，PR #331 补充函数 Schema 保留、转换和拒绝边界；PR #332 补充用户图片输入，本轮补充缓存用量计量；跨协议推理、缓存控制和真实会话仍继续跟踪。原生保真和密钥限制语义仍是发布阻塞项；后续每一步可能需要多份聚焦 PR。
+步骤 1 已完成；步骤 2 已完成 16 份录制样本分类、OpenAI Chat／Anthropic Messages 原生增量及单候选 Gemini mock 验证，无状态 Responses 原生 mock 验证也已完成；PR #329 补充四种入口到 Anthropic 的完整并行工具结果历史转换，PR #330 补充工具错误、空／分块文本结果及 Gemini ID／批次语义，PR #331 补充函数 Schema 保留、转换和拒绝边界；PR #332 补充用户图片输入，PR #333 补充缓存用量计量，本轮补充按官方定义的缓存控制；跨协议推理、严格断点转换和真实会话仍继续跟踪。原生保真和密钥限制语义仍是发布阻塞项；后续每一步可能需要多份聚焦 PR。
 
 复用[现有录制 fixture](../../tests/e2e/fixtures)和[旧回放矩阵](../../tests/e2e/proxy/test_protocol_matrix.py)作为输入，不能把它们当作新代理已通过的证据。旧 harness 依赖旧配置／工具流程，部分断言仅检查文本锚点／字段名；新断言必须核对有效内容顺序、工具 ID／参数、用量、凭证隔离和终态。端到端认证需记录客户端版本，本地 mock 不代表当前 SDK／厂商兼容。
 
@@ -354,3 +354,35 @@ python3 tests/proxy_reload_smoke.py
 310 项 Rust 测试（本轮新增 9 项）、Clippy、非桌面 workspace 检查、构建和五组进程回归通过。16 份录制样本原生精确回放及默认严格／显式 false 分类通过；格式、diff 和 104 个文档相对链接检查通过。`docs/superpowers/` 继续忽略，不进入 Git。
 
 本轮不新增 crate、依赖或内核职责，不实现请求 cache_control 映射、缓存放置、金额折扣或缓存执行服务。G03 仍为部分完成，推理／签名、缓存控制、其余媒体及完整客户端会话继续跟踪。使用本地 mock 和已有录制样本，没有使用真实厂商密钥。整体迁移完成后删除本文，不归档。
+
+## 17. G03 官方缓存控制与放置边界
+
+以当前官方文档确定字段、默认行为与语义。旧 Anthropic decoder 的 `map_cache_control` 将 TTL 固定为五分钟，encoder 则依赖原始请求快照保留断点；不能把这段实现或通用缓存类型的注释当成跨协议转换依据。新实现保持厂商控制独立，不新增统一缓存策略或 crate。
+
+- OpenAI 当前 `prompt_cache_options` 支持可选 mode（implicit／explicit）与 TTL（30m）；Chat／Responses 间保留结构，不注入省略字段。严格转换接受空对象，顶层 null 归一化为缺省；拒绝错误枚举、嵌套 null 及未实现的比较／诊断字段。
+- `prompt_cache_retention` 作为兼容字段接受 in_memory／24h，不是新默认值。它与 options TTL 的含义分别为最长保留策略、最短存活时间，不相互改写；两者可独立保留。模型是否支持由上游判断，既有 prompt_cache_key 不改写、不生成。
+- Responses 合法 options 回显沿用请求回显的校验／归一化契约，原生模式才能保证原样回显。OpenAI 逐块 breakpoint 仍由原生路径保留；严格转换拒绝，explicit 模式无断点时不合成隐式缓存。
+- Anthropic 顶层自动缓存，以及 system／tool／用户图片／文本／工具结果中的位置、顺序和 TTL，在匹配原生路径保持不变。Gemini 已有 cachedContent 引用也原样保留；不在 Nyro 中创建或迁移资源。JSON／SSE 的失败重试排除严格与其他协议候选，原始控制不会静默丢失。
+- 独立审查指出，新的 OpenAI 请求选项还要求处理官方 `cache_write_tokens`，否则连合法零写入响应也会被拒绝。已先复现再补齐 Chat／Responses 的 JSON／SSE 字段，复用 IR `Usage.cache_creation` 且不推测 TTL。写入与读取是输入内互斥子集，合计不得超过输入，零写入归一化为缺省。无 TTL 写入量可转换到 OpenAI Chat／Responses／Anthropic；Anthropic TTL 明细不能丢弃，Gemini 非零写入仍明确拒绝。原生 Chat／Responses 同步校验已知写入子集，其他 JSON 扩展原样保留。
+
+新增 6 项 [codec 测试](../../crates/nyro-llm/tests/cache_control_codec.rs)，覆盖两种 OpenAI API 的保留、缺省和拒绝边界及 Responses 回显。新增[请求矩阵](../../crates/nyro-llm/tests/responses_runtime.rs)核对 JSON／SSE 的实际发送字段、合法回显和不兼容目标；新增 [Anthropic](../../crates/nyro-llm/tests/native_anthropic_runtime.rs) 与 [Gemini](../../crates/nyro-llm/tests/native_gemini_runtime.rs) 各一项原生重试回归，使用仅含缓存控制的输入排除其他扩展导致拒绝的假阳性。OpenAI／Responses 既有原生精确保真样本补充当前缓存 options 与内容断点。
+
+额外增加 2 项[缓存用量 codec 回归](../../crates/nyro-llm/tests/cache_usage_codec.rs)，覆盖无 TTL 写入转换、零值、无效数值和子集溢出；新增原生 Chat 无效写入回归，并扩展 Responses 无效 JSON／SSE 样本。严格 HTTP 矩阵使用真实字段形状的缓存读取／写入用量，额外的 quota 测试确认两次各 5 token 消耗刚好耗尽 10 token，关闭 Chat 流式 usage 也不漏计、不重复计量。
+
+最终验证：
+
+```sh
+cargo test -p nyro-protocol -p nyro-llm -p nyro-config -p nyro --offline
+cargo clippy -p nyro-protocol -p nyro-llm -p nyro-config -p nyro --all-targets --offline -- -D warnings
+cargo check --workspace --exclude nyro-desktop --offline
+cargo build -p nyro --offline
+python3 tests/proxy_native_replay.py
+python3 tests/proxy_gemini_native_smoke.py
+python3 tests/proxy_responses_native_smoke.py
+python3 tests/proxy_smoke.py
+python3 tests/proxy_reload_smoke.py
+```
+
+323 项 Rust 测试（新增 13 项）、Clippy、非桌面 workspace 检查、构建及五组进程回归通过。16 份原生录制精确回放与默认严格／显式 false 分类保持通过；格式、diff 和 111 个文档相对链接检查通过。独立审查发现的写入用量缺口已补齐，复查未发现新的阻断问题。完整回归另确认：没有写入字段的旧 OpenAI 无效总量仍由既有观测／quota 契约处理，不因本轮添加字段校验而改变行为。
+
+G03 仍为部分完成：严格内容断点、跨协议策略、其他未实现用量扩展、推理／签名和其余媒体继续跟踪。官方来源及用户可用字段矩阵见[代理指南](../standalone/rust-proxy_CN.md#请求缓存控制)。这里没有真实厂商请求或缓存命中验证。整体迁移完成后删除本文，不做归档；`docs/superpowers/` 继续忽略。

--- a/docs/standalone/rust-proxy.md
+++ b/docs/standalone/rust-proxy.md
@@ -225,15 +225,36 @@ The strict conversion path is an experimental Chat subset for text, user image i
 
 Protocol reference: [Anthropic streaming](https://platform.claude.com/docs/en/build-with-claude/streaming), [Gemini generateContent](https://ai.google.dev/api/generate-content). Local matrix regression: `cargo test -p nyro-llm --test protocol_matrix`.
 
+## Request cache controls
+
+Cache controls follow the official API definitions; legacy adapters are migration evidence, not a source of defaults or equivalent mappings. The current strict subset is:
+
+| Control | Strict conversion | Matching native forwarding |
+|---|---|---|
+| OpenAI `prompt_cache_options` | Chat Completions ↔ Responses; optional `mode: implicit/explicit` and `ttl: 30m`. | Preserved. |
+| OpenAI `prompt_cache_key` | Preserved between Chat and Responses; Nyro does not generate a key. | Preserved. |
+| OpenAI `prompt_cache_retention` | Compatibility field: `in_memory` or `24h`, preserved between Chat and Responses. | Preserved. |
+| OpenAI per-block `prompt_cache_breakpoint` and Responses cache comparison/diagnostic controls | Not implemented; rejected before dispatch. | Preserved within the existing stateless native contract. |
+| Anthropic automatic or per-block `cache_control` | Not implemented; rejected before dispatch. | Preserves position, content order, explicit `5m`/`1h` TTL and omitted TTL. |
+| Gemini `cachedContent` | Not implemented; rejected before dispatch. | Preserves the existing cache resource reference. |
+
+For example, an OpenAI Chat or Responses request can include `"prompt_cache_options":{"mode":"implicit","ttl":"30m"}`. Omitted fields are not filled in by Nyro; an empty options object stays empty, and a null top-level options/retention value normalizes to absence in strict conversion. Nested mode/TTL values must match the supported enum and cannot be null. Model support and defaults remain the upstream's responsibility. In `explicit` mode without explicit breakpoints, OpenAI disables implicit caching; strict mode does not insert breakpoints, so use matching native forwarding when sending them.
+
+The current OpenAI API distinguishes the minimum lifetime in `prompt_cache_options.ttl` from the deprecated maximum retention policy in `prompt_cache_retention`; both fields may be supplied and are preserved independently. Nyro does not replace one with the other, translate them into Anthropic TTLs, or manufacture Gemini cache resources. OpenAI controls make Anthropic/Gemini targets ineligible before dispatch. Native-only controls also exclude strict or incompatible retry candidates. Matching protocol alone does not establish that a referenced cache exists for another upstream credential/model.
+
+Responses cache-option envelope echoes are validated and normalized with other request echoes; exact echoes require native forwarding. Cache storage, resource creation/deletion, automatic breakpoint placement and model-specific cache availability are not implemented by Nyro. The corresponding OpenAI `cache_write_tokens` counters are supported by the [usage conversion subset](#cache-usage-accounting); other unimplemented usage extensions still fail strict conversion.
+
+Sources: [OpenAI cache controls](https://developers.openai.com/api/docs/guides/prompt-caching), [Chat API fields](https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create), [Responses API fields](https://developers.openai.com/api/reference/cli/resources/responses/methods/create), [Anthropic cache placement](https://platform.claude.com/docs/en/build-with-claude/prompt-caching), [Gemini cached content](https://ai.google.dev/api/generate-content). Tests use local HTTP fixtures and assert sent fields, JSON/SSE completion, rejection before dispatch, retry eligibility and admission release; they do not certify vendor cache hits or billing.
+
 ## Cache usage accounting
 
 Strict conversion accepts Anthropic JSON/SSE cache-read and cache-creation token counts. Total input is `input_tokens + cache_read_input_tokens + cache_creation_input_tokens`; output is added once. The optional `cache_creation` five-minute and one-hour counters must sum to cache creation and are not added again. Counts must be nonnegative integers without overflow; supplied nulls and inconsistent breakdowns fail validation. Stream snapshots are cumulative: omitted input/cache fields retain their previous values, and individual counters cannot decrease.
 
-Cache reads map to OpenAI Chat cached prompt tokens, Responses cached input tokens, and Gemini cached content tokens. Positive cache writes and their optional TTL breakdown survive strict Anthropic output, but the other three output formats cannot represent them and reject the response (`502` or a terminated SSE stream). This also applies when OpenAI stream usage output is disabled; disabling usage does not authorize discarding incompatible metadata. Zero cache creation and a valid zero breakdown normalize away.
+Cache reads map to OpenAI Chat cached prompt tokens, Responses cached input tokens, and Gemini cached content tokens. OpenAI Chat `prompt_tokens_details.cache_write_tokens` and Responses `input_tokens_details.cache_write_tokens` are part of their inclusive input count, not additional tokens. Read plus write counts must fit within input. Writes without TTL details can convert between OpenAI Chat, Responses and Anthropic; Nyro does not infer TTL from request options. Anthropic's optional TTL breakdown is preserved only by Anthropic output, and Gemini output still rejects positive writes. Unsupported output details fail with `502` or a terminated SSE stream, even if OpenAI stream usage output is disabled. Zero writes and valid zero TTL breakdowns normalize away.
 
 Quota and observations use inclusive token totals, without cache pricing discounts or TTL multipliers. Valid usage already received remains chargeable if output conversion fails; failure settlement uses the existing maximum of reserved and known usage. Request `cache_control`, cache placement and cross-protocol cache policy remain unsupported in strict conversion. Matching native forwarding preserves these fields and validates known cache counters and TTL sums without adding the breakdown twice.
 
-Reference: [Anthropic prompt cache accounting](https://platform.claude.com/docs/en/build-with-claude/prompt-caching). Local regressions: `cargo test -p nyro-llm --test cache_usage_codec --test native_anthropic_runtime`. These use synthetic local upstreams, not vendor billing certification.
+References: [OpenAI cache read/write accounting](https://developers.openai.com/api/docs/guides/prompt-caching), [Anthropic prompt cache accounting](https://platform.claude.com/docs/en/build-with-claude/prompt-caching). Local regressions: `cargo test -p nyro-llm --test cache_usage_codec --test native_anthropic_runtime`. These use synthetic local upstreams, not vendor billing certification.
 
 ## User image inputs
 

--- a/docs/standalone/rust-proxy_CN.md
+++ b/docs/standalone/rust-proxy_CN.md
@@ -225,15 +225,36 @@ curl http://127.0.0.1:19530/v1beta/models/gemini-default:generateContent \
 
 协议参考：[Anthropic streaming](https://platform.claude.com/docs/en/build-with-claude/streaming)、[Gemini generateContent](https://ai.google.dev/api/generate-content)。本地矩阵回归：`cargo test -p nyro-llm --test protocol_matrix`。
 
+## 请求缓存控制
+
+缓存控制以官方 API 定义为准；旧适配器仅作为迁移证据，不决定默认值或等价映射。当前严格转换子集如下：
+
+| 控制字段 | 严格转换 | 匹配的原生转发 |
+|---|---|---|
+| OpenAI `prompt_cache_options` | Chat Completions ↔ Responses；可选 `mode: implicit/explicit` 和 `ttl: 30m`。 | 原样保留。 |
+| OpenAI `prompt_cache_key` | 在 Chat／Responses 之间保留，Nyro 不生成 key。 | 原样保留。 |
+| OpenAI `prompt_cache_retention` | 兼容字段：`in_memory` 或 `24h`，在 Chat／Responses 之间保留。 | 原样保留。 |
+| OpenAI 内容块 `prompt_cache_breakpoint`、Responses 缓存比较／诊断控制 | 尚未实现，在请求上游前拒绝。 | 在既有无状态原生契约内保留。 |
+| Anthropic 自动或逐块 `cache_control` | 尚未实现，在请求上游前拒绝。 | 保留位置、内容顺序、显式 `5m`／`1h` TTL 及省略 TTL。 |
+| Gemini `cachedContent` | 尚未实现，在请求上游前拒绝。 | 保留已有缓存资源引用。 |
+
+例如，OpenAI Chat 或 Responses 请求可包含 `"prompt_cache_options":{"mode":"implicit","ttl":"30m"}`。Nyro 不填充省略的字段；空 options 对象保持为空，严格转换将顶层 options／retention 的 null 归一化为缺省。嵌套 mode／TTL 必须符合支持的枚举，不能为 null。模型支持范围与默认值由上游决定。OpenAI 的 `explicit` 模式在没有显式断点时禁用隐式缓存；严格转换不会插入断点，发送断点时应使用匹配的原生转发。
+
+当前 OpenAI API 区分 `prompt_cache_options.ttl` 的最短存活时间与已弃用 `prompt_cache_retention` 的最长保留策略；两者同时提供时分别保留。Nyro 不相互替换、不映射为 Anthropic TTL，也不生成 Gemini 缓存资源。带 OpenAI 控制字段时，Anthropic／Gemini 目标会在发送前被排除。仅原生支持的字段同样会排除严格或不兼容的重试候选。协议匹配不代表其他上游凭证／模型也能访问同一缓存资源。
+
+Responses 对缓存选项的响应回显随其他请求回显一起校验并归一化，要求精确保留回显时使用原生转发。Nyro 不实现缓存存储、资源创建／删除、自动插入断点或模型缓存可用性判断。与请求控制对应的 OpenAI `cache_write_tokens` 已纳入[用量转换子集](#缓存用量计量)；其他未实现的用量扩展仍会被严格转换拒绝。
+
+依据：[OpenAI 缓存控制](https://developers.openai.com/api/docs/guides/prompt-caching)、[Chat API 字段](https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create)、[Responses API 字段](https://developers.openai.com/api/reference/cli/resources/responses/methods/create)、[Anthropic 缓存放置](https://platform.claude.com/docs/en/build-with-claude/prompt-caching)、[Gemini 缓存引用](https://ai.google.dev/api/generate-content)。测试使用本地 HTTP fixture，核对发出的字段、JSON／SSE 完成、发送前拒绝、重试候选及准入释放；不代表厂商缓存命中或账单认证。
+
 ## 缓存用量计量
 
 严格转换支持 Anthropic JSON／SSE 的缓存读取和写入 token 计数。总输入为 `input_tokens + cache_read_input_tokens + cache_creation_input_tokens`，输出只相加一次。可选 `cache_creation` 中的五分钟与一小时计数之和必须等于缓存写入量，不重复计入总量。计数必须为非负整数且不溢出；显式 null 或不一致的明细会校验失败。流式快照为累计值：省略的输入／缓存字段保留旧值，各项计数不得递减。
 
-缓存读取映射到 OpenAI Chat 缓存 prompt token、Responses 缓存 input token 和 Gemini 缓存 content token。非零缓存写入及可选 TTL 明细在严格 Anthropic 输出中保留；其余三种输出格式无法表达，会拒绝响应（`502` 或终止 SSE 流）。关闭 OpenAI 流式用量输出也适用，不能因此静默丢弃不兼容的明细。零缓存写入及有效的零 TTL 明细归一化为缺省。
+缓存读取映射到 OpenAI Chat 缓存 prompt token、Responses 缓存 input token 和 Gemini 缓存 content token。OpenAI Chat 的 `prompt_tokens_details.cache_write_tokens` 与 Responses 的 `input_tokens_details.cache_write_tokens` 已包含在各自输入总量中，不重复相加；读取与写入之和不得超过输入。没有 TTL 明细的写入计数可在 OpenAI Chat、Responses、Anthropic 之间转换，不根据请求选项推测 TTL。Anthropic 的可选 TTL 明细仍仅由 Anthropic 输出保留，Gemini 输出仍拒绝非零写入。无法表示的输出明细返回 `502` 或终止 SSE 流，关闭 OpenAI 流式用量输出也适用。零写入及有效的零 TTL 明细归一化为缺省。
 
 Quota 与观测按包含缓存的 token 总量计量，不应用缓存价格折扣或 TTL 倍率。输出转换失败时，已收到的有效用量仍参与扣减；失败结算继续采用预留与已知用量的较大值。严格转换仍不支持请求 `cache_control`、缓存放置及跨协议缓存策略。匹配的原生转发保留这些字段，并校验已知缓存计数和 TTL 合计，不重复累加明细。
 
-参考：[Anthropic 提示词缓存计量](https://platform.claude.com/docs/en/build-with-claude/prompt-caching)。本地回归：`cargo test -p nyro-llm --test cache_usage_codec --test native_anthropic_runtime`。使用合成本地上游，不代表厂商账单认证。
+参考：[OpenAI 缓存读写计量](https://developers.openai.com/api/docs/guides/prompt-caching)、[Anthropic 提示词缓存计量](https://platform.claude.com/docs/en/build-with-claude/prompt-caching)。本地回归：`cargo test -p nyro-llm --test cache_usage_codec --test native_anthropic_runtime`。使用合成本地上游，不代表厂商账单认证。
 
 ## 用户图片输入
 


### PR DESCRIPTION
Preserve OpenAI cache options and compatibility retention independently. Map cache write counts without double charging or inventing TTL details. Keep vendor-specific placement and resource references on native paths.

Direct OpenAiOptions and wire struct constructors must initialize the new optional cache fields; use None when absent.